### PR TITLE
relaxed bounds for ghc 781

### DIFF
--- a/Yesod/Auth/OAuth2.hs
+++ b/Yesod/Auth/OAuth2.hs
@@ -69,7 +69,7 @@ authOAuth2 name oauth getCreds = AuthPlugin name dispatch login
                 Left _ -> permissionDenied "Unable to retreive OAuth2 token"
                 Right token -> do
                     creds <- liftIO $ getCreds token
-                    lift $ setCreds True creds
+                    lift $ setCredsRedirect creds
 
         dispatch _ _ = notFound
 

--- a/yesod-auth-oauth2.cabal
+++ b/yesod-auth-oauth2.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth-oauth2
-version:         0.0.4
+version:         0.0.5
 license:         BSD3
 license-file:    LICENSE
 author:          Tom Streller
@@ -25,8 +25,8 @@ library
                    , http-conduit            >= 2.0       && < 3.0
                    , http-types              >= 0.8       && < 0.9
                    , aeson                   >= 0.6       && < 0.8
-                   , yesod-core              >= 1.2       && < 1.3
-                   , yesod-auth              >= 1.2       && < 1.3
+                   , yesod-core              >= 1.2       && < 1.4
+                   , yesod-auth              >= 1.2       && < 1.4
                    , text                    >= 0.7       && < 2.0
                    , yesod-form              >= 1.3       && < 1.4
                    , transformers            >= 0.2.2     && < 0.4


### PR DESCRIPTION
This patch works for us. yesod-auth should be bumped to 1.3 though.
