### PR TITLE
Expose auth2GithubScoped

### DIFF
--- a/Yesod/Auth/OAuth2/Github.hs
+++ b/Yesod/Auth/OAuth2/Github.hs
@@ -9,6 +9,7 @@
 --
 module Yesod.Auth.OAuth2.Github
     ( oauth2Github
+    , oauth2GithubScoped
     , module Yesod.Auth.OAuth2
     ) where
 


### PR DESCRIPTION
Expose auth2GithubScoped, allowing users to set the scopes themselves.
