### PR TITLE
Bump aeson version requirement

### DIFF
--- a/yesod-auth-oauth2.cabal
+++ b/yesod-auth-oauth2.cabal
@@ -33,7 +33,7 @@ library
     build-depends:   bytestring              >= 0.9.1.4
                    , http-conduit            >= 2.0       && < 3.0
                    , http-types              >= 0.8       && < 0.9
-                   , aeson                   >= 0.6       && < 0.8
+                   , aeson                   >= 0.6       && < 0.9
                    , yesod-core              >= 1.2       && < 1.5
                    , authenticate            >= 1.3.2.7   && < 1.4
                    , yesod-auth              >= 1.3       && < 1.5


### PR DESCRIPTION
Yesod 1.4 uses Aeson 0.8.0.1, which makes this library incompatible.
Bumping this to 0.9 matches Yesod's requirements.
