### PR TITLE
Use consistent style throughout project

### DIFF
--- a/Yesod/Auth/OAuth2.hs
+++ b/Yesod/Auth/OAuth2.hs
@@ -23,17 +23,17 @@ import Data.Text (Text, pack)
 import Data.Text.Encoding (decodeUtf8With, encodeUtf8)
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Typeable
+import Network.HTTP.Conduit (Manager)
 import Network.OAuth.OAuth2
-import Network.HTTP.Conduit(Manager)
 import System.Random
 import Yesod.Auth
 import Yesod.Core
 import Yesod.Form
 
-import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy as BL
 
 -- | Provider name and Aeson parse error
-data YesodOAuth2Exception = InvalidProfileResponse Text BSL.ByteString
+data YesodOAuth2Exception = InvalidProfileResponse Text BL.ByteString
     deriving (Show, Typeable)
 
 instance Exception YesodOAuth2Exception
@@ -52,52 +52,52 @@ authOAuth2 :: YesodAuth m
            -> AuthPlugin m
 authOAuth2 name oauth getCreds = AuthPlugin name dispatch login
 
-    where
-        url = PluginR name ["callback"]
+  where
+    url = PluginR name ["callback"]
 
-        withCallback csrfToken = do
-            tm <- getRouteToParent
-            render <- lift getUrlRender
-            return oauth
-                { oauthCallback = Just $ encodeUtf8 $ render $ tm url
-                , oauthOAuthorizeEndpoint = oauthOAuthorizeEndpoint oauth
-                    <> "&state=" <> encodeUtf8 csrfToken
-                }
+    withCallback csrfToken = do
+        tm <- getRouteToParent
+        render <- lift getUrlRender
+        return oauth
+            { oauthCallback = Just $ encodeUtf8 $ render $ tm url
+            , oauthOAuthorizeEndpoint = oauthOAuthorizeEndpoint oauth
+                <> "&state=" <> encodeUtf8 csrfToken
+            }
 
-        dispatch "GET" ["forward"] = do
-            csrfToken <- liftIO generateToken
-            setSession tokenSessionKey csrfToken
-            authUrl <- bsToText . authorizationUrl <$> withCallback csrfToken
-            lift $ redirect authUrl
+    dispatch "GET" ["forward"] = do
+        csrfToken <- liftIO generateToken
+        setSession tokenSessionKey csrfToken
+        authUrl <- bsToText . authorizationUrl <$> withCallback csrfToken
+        lift $ redirect authUrl
 
-        dispatch "GET" ["callback"] = do
-            newToken <- lookupGetParam "state"
-            oldToken <- lookupSession tokenSessionKey
-            deleteSession tokenSessionKey
-            case newToken of
-                Just csrfToken | newToken == oldToken -> do
-                    code <- lift $ runInputGet $ ireq textField "code"
-                    oauth' <- withCallback csrfToken
-                    master <- lift getYesod
-                    result <- liftIO $ fetchAccessToken (authHttpManager master) oauth' (encodeUtf8 code)
-                    case result of
-                        Left _ -> permissionDenied "Unable to retreive OAuth2 token"
-                        Right token -> do
-                            creds <- liftIO $ getCreds (authHttpManager master) token
-                            lift $ setCredsRedirect creds
-                _ ->
-                    permissionDenied "Invalid OAuth2 state token"
+    dispatch "GET" ["callback"] = do
+        newToken <- lookupGetParam "state"
+        oldToken <- lookupSession tokenSessionKey
+        deleteSession tokenSessionKey
+        case newToken of
+            Just csrfToken | newToken == oldToken -> do
+                code <- lift $ runInputGet $ ireq textField "code"
+                oauth' <- withCallback csrfToken
+                master <- lift getYesod
+                result <- liftIO $ fetchAccessToken (authHttpManager master) oauth' (encodeUtf8 code)
+                case result of
+                    Left _ -> permissionDenied "Unable to retreive OAuth2 token"
+                    Right token -> do
+                        creds <- liftIO $ getCreds (authHttpManager master) token
+                        lift $ setCredsRedirect creds
+            _ ->
+                permissionDenied "Invalid OAuth2 state token"
 
-        dispatch _ _ = notFound
+    dispatch _ _ = notFound
 
-        generateToken = pack . take 30 . randomRs ('a', 'z') <$> newStdGen
+    generateToken = pack . take 30 . randomRs ('a', 'z') <$> newStdGen
 
-        tokenSessionKey :: Text
-        tokenSessionKey = "_yesod_oauth2_" <> name
+    tokenSessionKey :: Text
+    tokenSessionKey = "_yesod_oauth2_" <> name
 
-        login tm = [whamlet|
-            <a href=@{tm $ oauth2Url name}>Login via #{name}
-            |]
+    login tm = [whamlet|
+        <a href=@{tm $ oauth2Url name}>Login via #{name}
+        |]
 
 bsToText :: ByteString -> Text
 bsToText = decodeUtf8With lenientDecode

--- a/Yesod/Auth/OAuth2/Upcase.hs
+++ b/Yesod/Auth/OAuth2/Upcase.hs
@@ -24,26 +24,26 @@ import Network.HTTP.Conduit(Manager)
 import qualified Data.Text as T
 
 data UpcaseUser = UpcaseUser
-    { upcaseUserId        :: Int
+    { upcaseUserId :: Int
     , upcaseUserFirstName :: Text
-    , upcaseUserLastName  :: Text
-    , upcaseUserEmail     :: Text
+    , upcaseUserLastName :: Text
+    , upcaseUserEmail :: Text
     }
 
 instance FromJSON UpcaseUser where
-    parseJSON (Object o) =
-        UpcaseUser <$> o .: "id"
-                  <*> o .: "first_name"
-                  <*> o .: "last_name"
-                  <*> o .: "email"
+    parseJSON (Object o) = UpcaseUser
+        <$> o .: "id"
+        <*> o .: "first_name"
+        <*> o .: "last_name"
+        <*> o .: "email"
 
     parseJSON _ = mzero
 
 data UpcaseResponse = UpcaseResponse UpcaseUser
 
 instance FromJSON UpcaseResponse where
-    parseJSON (Object o) =
-        UpcaseResponse <$> o .: "user"
+    parseJSON (Object o) = UpcaseResponse
+        <$> o .: "user"
 
     parseJSON _ = mzero
 
@@ -53,11 +53,11 @@ oauth2Upcase :: YesodAuth m
             -> AuthPlugin m
 oauth2Upcase clientId clientSecret = authOAuth2 "upcase"
     OAuth2
-        { oauthClientId            = encodeUtf8 clientId
-        , oauthClientSecret        = encodeUtf8 clientSecret
-        , oauthOAuthorizeEndpoint  = "http://upcase.com/oauth/authorize"
+        { oauthClientId = encodeUtf8 clientId
+        , oauthClientSecret = encodeUtf8 clientSecret
+        , oauthOAuthorizeEndpoint = "http://upcase.com/oauth/authorize"
         , oauthAccessTokenEndpoint = "http://upcase.com/oauth/token"
-        , oauthCallback            = Nothing
+        , oauthCallback = Nothing
         }
     fetchUpcaseProfile
 
@@ -70,9 +70,12 @@ fetchUpcaseProfile manager token = do
         Left err -> throwIO $ InvalidProfileResponse "upcase" err
 
 toCreds :: UpcaseUser -> Creds m
-toCreds user = Creds "upcase"
-    (T.pack $ show $ upcaseUserId user)
-    [ ("first_name", upcaseUserFirstName user)
-    , ("last_name" , upcaseUserLastName user)
-    , ("email"     , upcaseUserEmail user)
-    ]
+toCreds user = Creds
+    { credsPlugin = "upcase"
+    , credsIdent = T.pack $ show $ upcaseUserId user
+    , credsExtra =
+        [ ("first_name", upcaseUserFirstName user)
+        , ("last_name" , upcaseUserLastName user)
+        , ("email"     , upcaseUserEmail user)
+        ]
+    }


### PR DESCRIPTION
- Alphabetize imports
- Place qualified imports separate and last
- BL for ByteString.Lazy
- Don't align tokens in tuple lists or record assignments
- Two-space indent for where keyword
- Use record syntax for Creds
- Break before operators in Applicative expressions
- Consistent whitespace throughout

Resolves #19