### PR TITLE
Add a better .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,37 @@
-language: haskell
+env:
+ - CABALVER=1.18 GHCVER=7.6.3
+ - CABALVER=1.18 GHCVER=7.8.4
+ - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=head GHCVER=head
 
-ghc:
-  - "7.6"
-  - "7.8"
-  # - "7.10" not available yet
+matrix:
+ allow_failures:
+  - env: CABALVER=head GHCVER=head
+
+install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+script:
+ - cabal configure --enable-tests --enable-benchmarks -v2
+ - cabal build
+ - cabal test
+ - cabal check
+ - cabal sdist
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+   cd dist/;
+   if [ -f "$SRC_TGZ" ]; then
+      cabal install --force-reinstalls "$SRC_TGZ";
+   else
+      echo "expected '$SRC_TGZ' not found";
+      exit 1;
+   fi
 
 notifications:
   email: false


### PR DESCRIPTION
- Runs check and sdist, in addition to build/test
- Based on https://github.com/hvr/multi-ghc-travis
- Tests various combinations of Cabal and GHC (including 7.10)
- Tests HEAD versions, but allows failure there