### PR TITLE
Properly capitalise GitHub link

### DIFF
--- a/Yesod/Auth/OAuth2/Github.hs
+++ b/Yesod/Auth/OAuth2/Github.hs
@@ -67,7 +67,7 @@ oauth2GithubScoped :: YesodAuth m
              -> Text -- ^ Client Secret
              -> [Text] -- ^ List of scopes to request
              -> AuthPlugin m
-oauth2GithubScoped clientId clientSecret scopes = authOAuth2 "github" oauth fetchGithubProfile
+oauth2GithubScoped clientId clientSecret scopes = authOAuth2 "GitHub" oauth fetchGithubProfile
   where
     oauth = OAuth2
         { oauthClientId = encodeUtf8 clientId


### PR DESCRIPTION
currently the generated link says "Login with github"; it'd be nicer if it said "Login with GitHub". this pr makes it so.