### PR TITLE
Relax bound on transformers for GHC 8

### DIFF
--- a/yesod-auth-oauth2.cabal
+++ b/yesod-auth-oauth2.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth-oauth2
-version:         0.1.8
+version:         0.1.8.1
 license:         BSD3
 license-file:    LICENSE
 author:          Tom Streller
@@ -38,7 +38,7 @@ library
                    , yesod-auth              >= 1.3       && < 1.5
                    , text                    >= 0.7       && < 2.0
                    , yesod-form              >= 1.3       && < 1.5
-                   , transformers            >= 0.2.2     && < 0.5
+                   , transformers            >= 0.2.2     && < 0.6
                    , hoauth2                 >= 0.4.7     && < 0.6
                    , lifted-base             >= 0.2       && < 0.4
                    , vector                  >= 0.10      && < 0.12


### PR DESCRIPTION
I've tested this change against stackage nightly-2016-06-08 using a small example (not the one in the repo, which seems to fall foul of https://ghc.haskell.org/trac/ghc/ticket/12130, but similar).

When released, I am quite happy to PR the re-enabling of this package in stackage.