### PR TITLE
Properly handle empty "location" fields.

### DIFF
--- a/Yesod/Auth/OAuth2.hs
+++ b/Yesod/Auth/OAuth2.hs
@@ -15,6 +15,7 @@ module Yesod.Auth.OAuth2
     , oauth2Url
     , fromProfileURL
     , YesodOAuth2Exception(..)
+    , maybeExtra
     , module Network.OAuth.OAuth2
     ) where
 
@@ -149,3 +150,9 @@ appendQuery url query =
     if '?' `C8.elem` url
         then url <> "&" <> query
         else url <> "?" <> query
+
+-- | A helper for providing an optional value to credsExtra
+--
+maybeExtra :: Text -> Maybe Text -> [(Text, Text)]
+maybeExtra k (Just v) = [(k, v)]
+maybeExtra _ Nothing  = []

--- a/Yesod/Auth/OAuth2/Github.hs
+++ b/Yesod/Auth/OAuth2/Github.hs
@@ -37,7 +37,7 @@ data GithubUser = GithubUser
     , githubUserName :: Maybe Text
     , githubUserLogin :: Text
     , githubUserAvatarUrl :: Text
-    , githubUserLocation :: Text
+    , githubUserLocation :: Maybe Text
     , githubUserPublicEmail :: Maybe Text
     }
 
@@ -47,8 +47,8 @@ instance FromJSON GithubUser where
         <*> o .:? "name"
         <*> o .: "login"
         <*> o .: "avatar_url"
-        <*> o .: "location"
-        <*> o .: "email"
+        <*> o .:? "location"
+        <*> o .:? "email"
 
     parseJSON _ = mzero
 
@@ -104,11 +104,11 @@ toCreds user userMails token = Creds
         [ ("email", githubUserEmailAddress email)
         , ("login", githubUserLogin user)
         , ("avatar_url", githubUserAvatarUrl user)
-        , ("location", githubUserLocation user)
         , ("access_token", decodeUtf8 $ accessToken token)
         ]
         ++ maybeName (githubUserName user)
         ++ maybePublicEmail (githubUserPublicEmail user)
+        ++ maybeLocation (githubUserLocation user)
     }
 
   where
@@ -119,3 +119,6 @@ toCreds user userMails token = Creds
 
     maybePublicEmail Nothing = []
     maybePublicEmail (Just e) = [("public_email", e)]
+
+    maybeLocation Nothing = []
+    maybeLocation (Just location) = [("location", location)]

--- a/Yesod/Auth/OAuth2/Github.hs
+++ b/Yesod/Auth/OAuth2/Github.hs
@@ -106,19 +106,10 @@ toCreds user userMails token = Creds
         , ("avatar_url", githubUserAvatarUrl user)
         , ("access_token", decodeUtf8 $ accessToken token)
         ]
-        ++ maybeName (githubUserName user)
-        ++ maybePublicEmail (githubUserPublicEmail user)
-        ++ maybeLocation (githubUserLocation user)
+        ++ maybeExtra "name" (githubUserName user)
+        ++ maybeExtra "email" (githubUserPublicEmail user)
+        ++ maybeExtra "location" (githubUserLocation user)
     }
 
   where
     email = fromMaybe (head userMails) $ find githubUserEmailPrimary userMails
-
-    maybeName Nothing = []
-    maybeName (Just name) = [("name", name)]
-
-    maybePublicEmail Nothing = []
-    maybePublicEmail (Just e) = [("public_email", e)]
-
-    maybeLocation Nothing = []
-    maybeLocation (Just location) = [("location", location)]

--- a/Yesod/Auth/OAuth2/Google.hs
+++ b/Yesod/Auth/OAuth2/Google.hs
@@ -29,7 +29,6 @@ import Control.Exception.Lifted
 import Control.Monad (mzero)
 import Data.Aeson
 import Data.Monoid ((<>))
-import Data.Maybe (maybeToList)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
 import Network.HTTP.Conduit (Manager)
@@ -135,8 +134,6 @@ uidBuilder f user token = Creds
         , ("family_name", googleUserFamilyName user)
         , ("avatar_url", googleUserPicture user)
         , ("access_token", decodeUtf8 $ accessToken token)
-        ] ++ maybeHostedDomain
+        ]
+        ++ maybeExtra "hosted_domain" (googleUserHostedDomain user)
     }
-
-  where
-    maybeHostedDomain = maybeToList $ (,) "hosted_domain" <$> googleUserHostedDomain user

--- a/Yesod/Auth/OAuth2/Spotify.hs
+++ b/Yesod/Auth/OAuth2/Spotify.hs
@@ -33,8 +33,8 @@ data SpotifyUserImage = SpotifyUserImage
 
 instance FromJSON SpotifyUserImage where
     parseJSON (Object v) = SpotifyUserImage
-        <$> v .: "height"
-        <*> v .: "width"
+        <$> v .:? "height"
+        <*> v .:? "width"
         <*> v .: "url"
 
     parseJSON _ = mzero


### PR DESCRIPTION
Hi everyone,

This PR simply makes "location" optional. I recently configured a secondary github account to test my application with two different users. The new github account lacked several fields, including "location". Without this change, I would receive the following error:

```
20/Jun/2016:01:59:20 -0400 [Warn] Error Resp: InternalError "InvalidProfileResponse \"github\" \"hoauth2.HttpClient.parseResponseJSON/Could not decode JSON:
...
```

Upon further inspection, "location" was null. After making these changes and testing locally, I was able to successfully register via Github.

Thanks alot!

-- Andrew

