### PR TITLE
Slack.hs: fix haddock markup

### DIFF
--- a/Yesod/Auth/OAuth2/Slack.hs
+++ b/Yesod/Auth/OAuth2/Slack.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
---
+-- |
 -- OAuth2 plugin for https://slack.com/
 --
 -- * Authenticates against slack


### PR DESCRIPTION
haddock complained thusly:
  Yesod/Auth/OAuth2/Slack.hs:9:1: error:
    parse error on input ‘module’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>