### PR TITLE
Rename creds key `email` -> `public_email`

### DIFF
--- a/Yesod/Auth/OAuth2/Github.hs
+++ b/Yesod/Auth/OAuth2/Github.hs
@@ -107,7 +107,7 @@ toCreds user userMails token = Creds
         , ("access_token", decodeUtf8 $ accessToken token)
         ]
         ++ maybeExtra "name" (githubUserName user)
-        ++ maybeExtra "email" (githubUserPublicEmail user)
+        ++ maybeExtra "public_email" (githubUserPublicEmail user)
         ++ maybeExtra "location" (githubUserLocation user)
     }
 


### PR DESCRIPTION
We had a name collision when trying to grab the GitHub user's email
address, so if the user did not have a public email address the
authentication would fail with a 500 (InvalidProfileResponse).