### PR TITLE
Relax upper bounds on aeson and http-client

### DIFF
--- a/yesod-auth-oauth2.cabal
+++ b/yesod-auth-oauth2.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth-oauth2
-version:         0.2.2
+version:         0.2.3
 license:         BSD3
 license-file:    LICENSE
 author:          Tom Streller
@@ -28,10 +28,10 @@ library
 
     build-depends:   base                    >= 4.5       && < 5
                    , bytestring              >= 0.9.1.4
-                   , http-client             >= 0.4.0     && < 0.5
+                   , http-client             >= 0.4.0     && < 0.6
                    , http-conduit            >= 2.0       && < 3.0
                    , http-types              >= 0.8       && < 0.10
-                   , aeson                   >= 0.6       && < 0.12
+                   , aeson                   >= 0.6       && < 1.1
                    , yesod-core              >= 1.2       && < 1.5
                    , authenticate            >= 1.3.2.7   && < 1.4
                    , random


### PR DESCRIPTION
I've tested this in a small yesod application, authenticating against Google.  (I compiled it with GHC 8 and used stackage nightly-2016-11-12.)

These bounds are currently blocking this package in stackage nightly, and, when released, I am quite happy to submit a PR to re-enable it.