### PR TITLE
Allow use of any Slack scope

### DIFF
--- a/Yesod/Auth/OAuth2/Slack.hs
+++ b/Yesod/Auth/OAuth2/Slack.hs
@@ -7,7 +7,7 @@
 -- * Returns name, access_token, email, avatar, team_id, and team_name as extras
 --
 module Yesod.Auth.OAuth2.Slack
-    ( SlackScope(..)
+    ( defaultSlackIdentityScopes
     , oauth2Slack
     , oauth2SlackScoped
     ) where
@@ -26,10 +26,12 @@ import Network.HTTP.Conduit (Manager)
 import qualified Data.Text as Text
 import qualified Network.HTTP.Conduit as HTTP
 
-data SlackScope
-    = SlackEmailScope
-    | SlackTeamScope
-    | SlackAvatarScope
+defaultSlackIdentityScopes :: [Text]
+defaultSlackIdentityScopes =
+    [ "identity.email"
+    , "identity.team"
+    , "identity.avatar"
+    ]
 
 data SlackUser = SlackUser
     { slackUserId :: Text
@@ -80,7 +82,7 @@ oauth2Slack clientId clientSecret = oauth2SlackScoped clientId clientSecret []
 oauth2SlackScoped :: YesodAuth m
              => Text -- ^ Client ID
              -> Text -- ^ Client Secret
-             -> [SlackScope]
+             -> [Text]
              -> AuthPlugin m
 oauth2SlackScoped clientId clientSecret scopes =
     authOAuth2 "slack" oauth fetchSlackProfile
@@ -95,12 +97,7 @@ oauth2SlackScoped clientId clientSecret scopes =
         , oauthAccessTokenEndpoint = "https://slack.com/api/oauth.access"
         , oauthCallback = Nothing
         }
-    scopeTexts = "identity.basic":map scopeText scopes
-
-scopeText :: SlackScope -> Text
-scopeText SlackEmailScope = "identity.email"
-scopeText SlackTeamScope = "identity.team"
-scopeText SlackAvatarScope = "identity.avatar"
+    scopeTexts = "identity.basic":scopes
 
 fetchSlackProfile :: Manager -> AccessToken -> IO (Creds m)
 fetchSlackProfile manager token = do


### PR DESCRIPTION
I'd like to use `yesod-auth-oauth2`'s Slack provider to create a more fully-features Slack application that uses more capabilities of the Slack API. To do this, I need to be able to authenticate with more scopes.

This change removes the `SlackScope` type, and changes the API to take `[Text]` for the scopes (although retains a `defaultSlackIdentityScopes` definition).

I'm relatively new to working on other people's Haskell projects, and to designing Haskell APIs, so please consider this a 'first pass', I'd like any feedback you may have that could help me improve this to the point where it's mergeable.

Note that to get `yesod-auth-oauth2` to compile I did use the changes in #77.