### PR TITLE
Upgrade stack resolver

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,8 @@ dependencies:
   cache_directories:
     - "~/.stack"
   pre:
-    - wget https://github.com/commercialhaskell/stack/releases/download/v0.1.6.0/stack-0.1.6.0-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
-    - tar xvzOf /tmp/stack.tar.gz stack-0.1.6.0-linux-x86_64/stack > /tmp/stack
+    - wget https://github.com/commercialhaskell/stack/releases/download/v1.4.0/stack-1.4.0-linux-x86_64.tar.gz -O /tmp/stack.tar.gz
+    - tar xvzOf /tmp/stack.tar.gz stack-1.4.0-linux-x86_64/stack > /tmp/stack
     - chmod +x /tmp/stack && sudo mv /tmp/stack /usr/bin/stack
   override:
     - stack setup

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,6 @@ flags:
     network-uri: true
 packages:
 - '.'
-resolver: lts-3.5
+resolver: lts-8.23
 extra-deps:
 - load-env-0.1.1


### PR DESCRIPTION
Currently, `master` doesn't build on Sierra because of GHC 7.10 / stack issues: https://github.com/commercialhaskell/stack/issues/2841

Is there any reason we shouldn't update to the latest resolver?