### PR TITLE
Update Nylas provider

### DIFF
--- a/Yesod/Auth/OAuth2/Nylas.hs
+++ b/Yesod/Auth/OAuth2/Nylas.hs
@@ -16,13 +16,13 @@ import Data.Aeson (FromJSON, Value(..), parseJSON, decode, (.:))
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8)
-import Network.HTTP.Client (applyBasicAuth, parseUrl, httpLbs, responseStatus
-                           , responseBody)
+import Network.HTTP.Client (applyBasicAuth, httpLbs, parseRequest, responseBody,
+                            responseStatus)
 import Network.HTTP.Conduit (Manager)
 import Yesod.Auth (Creds(..), YesodAuth, AuthPlugin)
-import Yesod.Auth.OAuth2 (OAuth2(..), AccessToken(..)
-                         , YesodOAuth2Exception(InvalidProfileResponse)
-                         , authOAuth2)
+import Yesod.Auth.OAuth2 (OAuth2(..), AccessToken(..),
+                          YesodOAuth2Exception(InvalidProfileResponse),
+                          authOAuth2)
 import qualified Network.HTTP.Types as HT
 
 data NylasAccount = NylasAccount
@@ -61,7 +61,7 @@ oauth2Nylas clientId clientSecret = authOAuth2 "nylas" oauth fetchCreds
 
 fetchCreds :: Manager -> AccessToken -> IO (Creds a)
 fetchCreds manager token = do
-    req <- authorize <$> parseUrl "https://api.nylas.com/account"
+    req <- authorize <$> parseRequest "https://api.nylas.com/account"
     resp <- httpLbs req manager
     if HT.statusIsSuccessful (responseStatus resp)
         then case decode (responseBody resp) of

--- a/Yesod/Auth/OAuth2/Nylas.hs
+++ b/Yesod/Auth/OAuth2/Nylas.hs
@@ -23,8 +23,6 @@ import Yesod.Auth (Creds(..), YesodAuth, AuthPlugin)
 import Yesod.Auth.OAuth2 (OAuth2(..), AccessToken(..)
                          , YesodOAuth2Exception(InvalidProfileResponse)
                          , authOAuth2)
-
-import qualified Data.Text as T
 import qualified Network.HTTP.Types as HT
 
 data NylasAccount = NylasAccount
@@ -48,25 +46,16 @@ oauth2Nylas :: YesodAuth m
             => Text -- ^ Client ID
             -> Text -- ^ Client Secret
             -> AuthPlugin m
-oauth2Nylas = oauth2NylasScoped ["email"]
-
-oauth2NylasScoped :: YesodAuth m
-                  => [Text] -- ^ Scopes
-                  -> Text   -- ^ Client ID
-                  -> Text   -- ^ Client Secret
-                  -> AuthPlugin m
-oauth2NylasScoped scopes clientId clientSecret =
-    authOAuth2 "nylas" oauth fetchCreds
+oauth2Nylas clientId clientSecret = authOAuth2 "nylas" oauth fetchCreds
   where
-    authorizeUrl = encodeUtf8
-                 $ "https://api.nylas.com/oauth/authorize?scope="
-                 <> T.intercalate "," scopes
-    tokenUrl = "https://api.nylas.com/oauth/token"
+    authorizeUrl = encodeUtf8 $ "https://api.nylas.com/oauth/authorize" <>
+        "?response_type=code&scope=email&client_id=" <> clientId
+
     oauth = OAuth2
         { oauthClientId = encodeUtf8 clientId
         , oauthClientSecret = encodeUtf8 clientSecret
         , oauthOAuthorizeEndpoint = authorizeUrl
-        , oauthAccessTokenEndpoint = tokenUrl
+        , oauthAccessTokenEndpoint = "https://api.nylas.com/oauth/token"
         , oauthCallback = Nothing
         }
 


### PR DESCRIPTION
Hi there,

Since the last time I used this project, apparently Nylas has changed their API again and the current provider no longer works. The following patch adds `response_type` and `client_id` parameters to fix things up.

Also, because Nylas only allows `scope=email`, I've removed `oauth2NylasScoped`, which wasn't exported from the module anyway.

Thanks,
Brian