### PR TITLE
Stop returning extra information in GitHub result

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 OAuth2 `AuthPlugin`s for Yesod.
 
-## Basic Usage
+## Usage
 
-To use one of the supported providers:
-
-```haskell
+```hs
 import Yesod.Auth
 import Yesod.Auth.OAuth2.Github
 
@@ -25,56 +23,83 @@ clientSecret = "..."
 Some plugins, such as GitHub and Slack, have scoped functions for requesting
 additional information:
 
-```haskell
-import Yesod.Auth
-import Yesod.Auth.OAuth2.Slack
-
-instance YesodAuth App where
-    -- ...
-
-    authPlugins _ =
-        [oauth2SlackScoped clientId clientSecret slackScopes]
-      where
-        slackScopes = [SlackEmailScope, SlackAvatarScope, SlackTeamScope]
-
-clientId :: Text
-clientId = "..."
-
-clientSecret :: Text
-clientSecret = "..."
+```hs
+oauth2SlackScoped [SlackBasicScope, SlackEmailScope] clientId clientSecret
 ```
 
-## Advanced Usage
+## Working with Extra Data
 
-To use any other provider:
+We put the minimal amount of user data possible in `credsExtra` -- just enough
+to support you parsing or fetching additional data yourself.
+
+For example, if you work with GitHub and GitHub user profiles, you likely
+already have a model and a way to parse the `/user` response. Rather than
+duplicate all that in our own library, we try to make it easy for you to re-use
+that code yourself:
+
+```hs
+authenticate creds = do
+    let
+        -- You can run your own FromJSON parser on the respose we already have
+        eGitHubUser :: Either String GitHubUser
+        eGitHubUser = getUserResponse creds
+
+        -- Avert your eyes
+        Right githubUser = eGitHubUser
+
+    -- Or make followup requests using our access token
+    runGitHub (getAccessToken creds) $ userRepositories githubUser
+
+    -- Or store it for later
+    insert User
+        { userIdent = credsIdent creds
+        , userAccessToken = getAccessToken creds
+        }
+```
+
+**NOTE**: Avoid looking up values in `credsExtra` yourself; prefer the provided
+`get` functions. The data representation itself is no longer considered public
+API.
+
+## Local Providers
+
+If we don't supply a "Provider" (e.g. GitHub, Google, etc) you need. You can
+write your own within your codebase:
 
 ```haskell
-import Yesod.Auth
-import Yesod.Auth.OAuth2
+import Yesod.Auth.OAuth2.Prelude
 
-instance YesodAuth App where
-    -- ...
+pluginName :: Text
+pluginName = "mysite"
 
-    authPlugins _ = [myPlugin]
+oauth2MySite :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2MySite clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        -- Fetch a profile using the manager and token, leave it a ByteString
+        userResponseJSON <- -- ...
 
-myPlugin :: AuthPlugin m
-myPlugin = authOAuth2 "mysite"
-    (OAuth2
-        { oauthClientId            = "..."
-        , oauthClientSecret        = "..."
-        , oauthOAuthorizeEndpoint  = "https://mysite.com/oauth/authorize"
+        -- Parse it to your preferred identifier, see Data.Aeson
+        userId <- -- ...
+
+        -- See authGetProfile for the typical case
+
+        pure Creds
+            { credsPlugin = pluginName
+            , credsIdent = userId
+            , credsExtra = setExtra token userResponseJSON
+            }
+  where
+    oauth2 = OAuth2
+        { oauthClientId = clientId
+        , oauthClientSecret = clientSecret
+        , oauthOAuthorizeEndpoint = "https://mysite.com/oauth/authorize"
         , oauthAccessTokenEndpoint = "https://mysite.com/oauth/token"
-        , oauthCallback            = Nothing
-        })
-    makeCredentials
-
-makeCredentials :: Manager -> AccessToken -> IO (Creds m)
-makeCredentials manager token = do
-    result <- authGetJSON manager token "https://mysite.com/api/me.json"
-    return $ -- Parse the JSON into (Creds m)
+        , oauthCallback = Nothing
+        }
 ```
 
-*If you write one of these, please consider opening a Pull Request*
+The `Prelude` module is considered public API, though we may build something
+higher-level that is more convenient for this use-case in the future.
 
 ## Development & Tests
 
@@ -83,6 +108,8 @@ stack setup
 stack build --dependencies-only
 stack build --pedantic --test
 ```
+
+Please also run HLint and Weeder before submitting PRs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,16 +44,17 @@ authenticate creds = do
         eGitHubUser :: Either String GitHubUser
         eGitHubUser = getUserResponseJSON creds
 
-        -- Avert your eyes
+        -- Avert your eyes, simplified example
+        Just accessToken = getAccessToken creds
         Right githubUser = eGitHubUser
 
     -- Or make followup requests using our access token
-    runGitHub (getAccessToken creds) $ userRepositories githubUser
+    runGitHub accessToken $ userRepositories githubUser
 
     -- Or store it for later
     insert User
         { userIdent = credsIdent creds
-        , userAccessToken = getAccessToken creds
+        , userAccessToken = accessToken
         }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ authenticate creds = do
     let
         -- You can run your own FromJSON parser on the respose we already have
         eGitHubUser :: Either String GitHubUser
-        eGitHubUser = getUserResponse creds
+        eGitHubUser = getUserResponseJSON creds
 
         -- Avert your eyes
         Right githubUser = eGitHubUser
@@ -76,9 +76,9 @@ oauth2MySite :: YesodAuth m => Text -> Text -> AuthPlugin m
 oauth2MySite clientId clientSecret =
     authOAuth2 pluginName oauth2 $ \manager token -> do
         -- Fetch a profile using the manager and token, leave it a ByteString
-        userResponseJSON <- -- ...
+        userResponse <- -- ...
 
-        -- Parse it to your preferred identifier, see Data.Aeson
+        -- Parse it to your preferred identifier, e.g. with Data.Aeson
         userId <- -- ...
 
         -- See authGetProfile for the typical case
@@ -86,7 +86,7 @@ oauth2MySite clientId clientSecret =
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/package.yaml
+++ b/package.yaml
@@ -20,13 +20,13 @@ library:
   dependencies:
     - aeson >=0.6 && <1.3
     - bytestring >=0.9.1.4
+    - errors
     - hoauth2 >=1.3.0 && <1.6
     - http-client >=0.4.0 && <0.6
     - http-conduit >=2.0 && <3.0
     - http-types >=0.8 && <0.10
     - microlens
     - random
-    - safe
     - safe-exceptions
     - text >=0.7 && <2.0
     - transformers >=0.2.2 && <0.6

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ library:
     - http-types >=0.8 && <0.10
     - microlens
     - random
+    - safe
     - safe-exceptions
     - text >=0.7 && <2.0
     - transformers >=0.2.2 && <0.6

--- a/src/Yesod/Auth/OAuth2.hs
+++ b/src/Yesod/Auth/OAuth2.hs
@@ -16,11 +16,20 @@ module Yesod.Auth.OAuth2
     , oauth2Url
     , authOAuth2
     , authOAuth2Widget
+
+    -- * Reading our @'credsExtra'@ keys
+    , getAccessToken
+    , getUserResponseJSON
+    , getUserResponse
     ) where
 
+import Data.Aeson (FromJSON, eitherDecode)
+import Data.ByteString.Lazy (ByteString, fromStrict)
 import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Conduit (Manager)
 import Network.OAuth.OAuth2
+import Safe (fromJustNote)
 import Yesod.Auth
 import Yesod.Auth.OAuth2.Dispatch
 import Yesod.Core.Widget
@@ -51,3 +60,29 @@ authOAuth2Widget widget name oauth getCreds =
     AuthPlugin name (dispatchAuthRequest name oauth getCreds) login
   where
     login tm = [whamlet|<a href=@{tm $ oauth2Url name}>^{widget}|]
+
+-- | Read from the values set via @'setExtra'@
+--
+-- This is unsafe.
+--
+getAccessToken :: Creds m -> AccessToken
+getAccessToken = AccessToken
+    . fromJustNote "yesod-auth-oauth2 bug: credsExtra without accessToken"
+    . lookup "accessToken" . credsExtra
+
+-- | Read from the values set via @'setExtra'@
+--
+-- This is unsafe.
+--
+getUserResponseJSON :: Creds m -> ByteString
+getUserResponseJSON = fromStrict . encodeUtf8
+    . fromJustNote "yesod-auth-oauth2 bug: credsExtra without userResponseJSON"
+    . lookup "userResponseJSON" . credsExtra
+
+-- | Read from the values set via @'setExtra'@
+--
+-- This is unsafe if the key is missing, but safe with respect to parsing
+-- errors.
+--
+getUserResponse :: FromJSON a => Creds m -> Either String a
+getUserResponse = eitherDecode . getUserResponseJSON

--- a/src/Yesod/Auth/OAuth2.hs
+++ b/src/Yesod/Auth/OAuth2.hs
@@ -5,7 +5,7 @@
 --
 -- Generic OAuth2 plugin for Yesod
 --
--- See "Yesod.Auth.OAuth2.GitHub" for example usage.
+-- See @"Yesod.Auth.OAuth2.GitHub"@ for example usage.
 --
 module Yesod.Auth.OAuth2
     ( OAuth2(..)
@@ -40,7 +40,7 @@ oauth2Url name = PluginR name ["forward"]
 
 -- | Create an @'AuthPlugin'@ for the given OAuth2 provider
 --
--- Presents a generic @"Login via name"@ link
+-- Presents a generic @"Login via #{name}"@ link
 --
 authOAuth2 :: YesodAuth m => Text -> OAuth2 -> FetchCreds m -> AuthPlugin m
 authOAuth2 name = authOAuth2Widget [whamlet|Login via #{name}|] name

--- a/src/Yesod/Auth/OAuth2.hs
+++ b/src/Yesod/Auth/OAuth2.hs
@@ -19,8 +19,8 @@ module Yesod.Auth.OAuth2
 
     -- * Reading our @'credsExtra'@ keys
     , getAccessToken
-    , getUserResponseJSON
     , getUserResponse
+    , getUserResponseJSON
     ) where
 
 import Data.Aeson (FromJSON, eitherDecode)
@@ -74,15 +74,15 @@ getAccessToken = AccessToken
 --
 -- This is unsafe.
 --
-getUserResponseJSON :: Creds m -> ByteString
-getUserResponseJSON = fromStrict . encodeUtf8
-    . fromJustNote "yesod-auth-oauth2 bug: credsExtra without userResponseJSON"
-    . lookup "userResponseJSON" . credsExtra
+getUserResponse :: Creds m -> ByteString
+getUserResponse = fromStrict . encodeUtf8
+    . fromJustNote "yesod-auth-oauth2 bug: credsExtra without userResponse"
+    . lookup "userResponse" . credsExtra
 
--- | Read from the values set via @'setExtra'@
+-- | Read from the values set via @'setExtra'@, decode as JSON
 --
 -- This is unsafe if the key is missing, but safe with respect to parsing
 -- errors.
 --
-getUserResponse :: FromJSON a => Creds m -> Either String a
-getUserResponse = eitherDecode . getUserResponseJSON
+getUserResponseJSON :: FromJSON a => Creds m -> Either String a
+getUserResponseJSON = eitherDecode . getUserResponse

--- a/src/Yesod/Auth/OAuth2/BattleNet.hs
+++ b/src/Yesod/Auth/OAuth2/BattleNet.hs
@@ -14,7 +14,6 @@ module Yesod.Auth.OAuth2.BattleNet
 
 import Yesod.Auth.OAuth2.Prelude
 
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T (pack, toLower)
 import Yesod.Core.Widget
 
@@ -43,10 +42,7 @@ oAuth2BattleNet clientId clientSecret region widget =
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = T.pack $ show userId
-            , credsExtra =
-                [ ("accessToken", atoken $ accessToken token)
-                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
-                ]
+            , credsExtra = setExtra token userResponseJSON
             }
   where
     host = wwwHost $ T.toLower region

--- a/src/Yesod/Auth/OAuth2/BattleNet.hs
+++ b/src/Yesod/Auth/OAuth2/BattleNet.hs
@@ -35,14 +35,14 @@ oAuth2BattleNet
     -> AuthPlugin m
 oAuth2BattleNet clientId clientSecret region widget =
     authOAuth2Widget widget pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token
                 $ fromRelative "https" (apiHost $ T.toLower region) "/account/user"
 
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = T.pack $ show userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     host = wwwHost $ T.toLower region

--- a/src/Yesod/Auth/OAuth2/Bitbucket.hs
+++ b/src/Yesod/Auth/OAuth2/Bitbucket.hs
@@ -5,7 +5,6 @@
 --
 -- * Authenticates against bitbucket
 -- * Uses bitbucket uuid as credentials identifier
--- * Returns email, username, full name, location and avatar as extras
 --
 module Yesod.Auth.OAuth2.Bitbucket
     ( oauth2Bitbucket
@@ -14,74 +13,46 @@ module Yesod.Auth.OAuth2.Bitbucket
 
 import Yesod.Auth.OAuth2.Prelude
 
-import Data.List (find)
-import Data.Maybe (fromMaybe)
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 
-data BitbucketUser = BitbucketUser
-    { bitbucketUserId :: Text
-    , bitbucketUserName :: Maybe Text
-    , bitbucketUserLogin :: Text
-    , bitbucketUserLocation :: Maybe Text
-    , bitbucketUserLinks :: BitbucketUserLinks
-    }
+newtype User = User Text
 
-instance FromJSON BitbucketUser where
-    parseJSON = withObject "BitbucketUser" $ \o -> BitbucketUser
+instance FromJSON User where
+    parseJSON = withObject "User" $ \o -> User
         <$> o .: "uuid"
-        <*> o .:? "display_name"
-        <*> o .: "username"
-        <*> o .:? "location"
-        <*> o .: "links"
 
-newtype BitbucketUserLinks = BitbucketUserLinks
-    { bitbucketAvatarLink :: BitbucketLink
-    }
+pluginName :: Text
+pluginName = "bitbucket"
 
-instance FromJSON BitbucketUserLinks where
-    parseJSON = withObject "BitbucketUserLinks" $ \o -> BitbucketUserLinks
-        <$> o .: "avatar"
+defaultScopes :: [Text]
+defaultScopes = ["account"]
 
-newtype BitbucketLink = BitbucketLink
-    { bitbucketLinkHref :: Text
-    }
+oauth2Bitbucket :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2Bitbucket = oauth2BitbucketScoped defaultScopes
 
-instance FromJSON BitbucketLink where
-    parseJSON = withObject "BitbucketLink" $ \o -> BitbucketLink
-        <$> o .: "href"
+oauth2BitbucketScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2BitbucketScoped scopes clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        (User userId, userResponseJSON) <-
+            authGetProfile pluginName manager token "https://api.bitbucket.com/2.0/user"
 
-newtype BitbucketEmailSearchResults = BitbucketEmailSearchResults
-    { bitbucketEmails :: [BitbucketUserEmail]
-    }
-
-instance FromJSON BitbucketEmailSearchResults where
-    parseJSON = withObject "BitbucketEmailSearchResults" $ \o -> BitbucketEmailSearchResults
-        <$> o .: "values"
-
-data BitbucketUserEmail = BitbucketUserEmail
-    { bitbucketUserEmailAddress :: Text
-    , bitbucketUserEmailPrimary :: Bool
-    }
-
-instance FromJSON BitbucketUserEmail where
-    parseJSON = withObject "BitbucketUserEmail" $ \o -> BitbucketUserEmail
-        <$> o .: "email"
-        <*> o .: "is_primary"
-
-oauth2Bitbucket :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> AuthPlugin m
-oauth2Bitbucket clientId clientSecret = oauth2BitbucketScoped clientId clientSecret ["account"]
-
-oauth2BitbucketScoped :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> [Text] -- ^ List of scopes to request
-             -> AuthPlugin m
-oauth2BitbucketScoped clientId clientSecret scopes = authOAuth2 "bitbucket" oauth fetchBitbucketProfile
+        pure Creds
+            { credsPlugin = pluginName
+            -- FIXME: Preserved bug. This should just be userId (it's already
+            -- a Text), but because this code was shipped, folks likely have
+            -- Idents in their database like @"\"...\""@, and if we fixed this
+            -- they would need migrating. We're keeping it for now as it's a
+            -- minor wart. Breaking typed APIs is one thing, causing data to go
+            -- invalid is another.
+            , credsIdent = T.pack $ show userId
+            , credsExtra =
+                [ ("accessToken", atoken $ accessToken token)
+                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
+                ]
+            }
   where
-    oauth = OAuth2
+    oauth2 = OAuth2
         { oauthClientId = clientId
         , oauthClientSecret = clientSecret
         , oauthOAuthorizeEndpoint = "https://bitbucket.com/site/oauth2/authorize" `withQuery`
@@ -90,30 +61,3 @@ oauth2BitbucketScoped clientId clientSecret scopes = authOAuth2 "bitbucket" oaut
         , oauthAccessTokenEndpoint = "https://bitbucket.com/site/oauth2/access_token"
         , oauthCallback = Nothing
         }
-
-fetchBitbucketProfile :: Manager -> OAuth2Token -> IO (Creds m)
-fetchBitbucketProfile manager token = do
-    userResult <- authGetJSON manager (accessToken token) "https://api.bitbucket.com/2.0/user"
-    mailResult <- authGetJSON manager (accessToken token) "https://api.bitbucket.com/2.0/user/emails"
-
-    case (userResult, mailResult) of
-        (Right user, Right mails) -> return $ toCreds user (bitbucketEmails mails) token
-        (Left err, _) -> throwIO $ invalidProfileResponse "bitbucket" err
-        (_, Left err) -> throwIO $ invalidProfileResponse "bitbucket" err
-
-toCreds :: BitbucketUser -> [BitbucketUserEmail] -> OAuth2Token -> Creds m
-toCreds user userMails token = Creds
-    { credsPlugin = "bitbucket"
-    , credsIdent = T.pack $ show $ bitbucketUserId user
-    , credsExtra =
-        [ ("email", bitbucketUserEmailAddress email)
-        , ("login", bitbucketUserLogin user)
-        , ("avatar_url", bitbucketLinkHref (bitbucketAvatarLink (bitbucketUserLinks user)))
-        , ("access_token", atoken $ accessToken token)
-        ]
-        ++ maybeExtra "name" (bitbucketUserName user)
-        ++ maybeExtra "location" (bitbucketUserLocation user)
-    }
-
-  where
-    email = fromMaybe (head userMails) $ find bitbucketUserEmailPrimary userMails

--- a/src/Yesod/Auth/OAuth2/Bitbucket.hs
+++ b/src/Yesod/Auth/OAuth2/Bitbucket.hs
@@ -33,7 +33,7 @@ oauth2Bitbucket = oauth2BitbucketScoped defaultScopes
 oauth2BitbucketScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
 oauth2BitbucketScoped scopes clientId clientSecret =
     authOAuth2 pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token "https://api.bitbucket.com/2.0/user"
 
         pure Creds
@@ -45,7 +45,7 @@ oauth2BitbucketScoped scopes clientId clientSecret =
             -- minor wart. Breaking typed APIs is one thing, causing data to go
             -- invalid is another.
             , credsIdent = T.pack $ show userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Bitbucket.hs
+++ b/src/Yesod/Auth/OAuth2/Bitbucket.hs
@@ -13,7 +13,6 @@ module Yesod.Auth.OAuth2.Bitbucket
 
 import Yesod.Auth.OAuth2.Prelude
 
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 
 newtype User = User Text
@@ -46,10 +45,7 @@ oauth2BitbucketScoped scopes clientId clientSecret =
             -- minor wart. Breaking typed APIs is one thing, causing data to go
             -- invalid is another.
             , credsIdent = T.pack $ show userId
-            , credsExtra =
-                [ ("accessToken", atoken $ accessToken token)
-                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
-                ]
+            , credsExtra = setExtra token userResponseJSON
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -22,10 +22,6 @@ import Yesod.Auth
 import Yesod.Core
 
 -- | How to take an @'OAuth2Token'@ and retrieve user credentials
---
--- Usually this means a second authorized request to @api/me.json@. See
--- @'fromProfileURL'@ for an example.
---
 type FetchCreds m = Manager -> OAuth2Token -> IO (Creds m)
 
 -- | Dispatch the various OAuth2 handshake routes

--- a/src/Yesod/Auth/OAuth2/EveOnline.hs
+++ b/src/Yesod/Auth/OAuth2/EveOnline.hs
@@ -6,7 +6,6 @@
 --
 -- * Authenticates against eveonline
 -- * Uses EVEs unique account-user-char-hash as credentials identifier
--- * Returns charName, charId, tokenType, accessToken and expires as extras
 --
 module Yesod.Auth.OAuth2.EveOnline
     ( oauth2Eve
@@ -16,8 +15,15 @@ module Yesod.Auth.OAuth2.EveOnline
 
 import Yesod.Auth.OAuth2.Prelude
 
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import Yesod.Core.Widget
+
+newtype User = User Text
+
+instance FromJSON User where
+    parseJSON = withObject "User" $ \o -> User
+        <$> o .: "CharacterOwnerHash"
 
 data WidgetType m
     = Plain -- ^ Simple "Login via eveonline" text
@@ -27,49 +33,40 @@ data WidgetType m
     | SmallBlack
     | Custom (WidgetT m IO ())
 
-data EveUser = EveUser
-    { eveUserName :: Text
-    , eveUserExpire :: Text
-    , eveTokenType :: Text
-    , eveCharOwnerHash :: Text
-    , eveCharId :: Integer
-    }
+asWidget :: YesodAuth m => WidgetType m -> WidgetT m IO ()
+asWidget Plain = [whamlet|Login via eveonline|]
+asWidget BigWhite = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/4PTzeiAshqiM8osU2giO0Y/5cc4cb60bac52422da2e45db87b6819c/EVE_SSO_Login_Buttons_Large_White.png?w=270&h=45">|]
+asWidget BigBlack = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/4fSjj56uD6CYwYyus4KmES/4f6385c91e6de56274d99496e6adebab/EVE_SSO_Login_Buttons_Large_Black.png?w=270&h=45">|]
+asWidget SmallWhite = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/18BxKSXCymyqY4QKo8KwKe/c2bdded6118472dd587c8107f24104d7/EVE_SSO_Login_Buttons_Small_White.png?w=195&h=30">|]
+asWidget SmallBlack = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/12vrPsIMBQi28QwCGOAqGk/33234da7672c6b0cdca394fc8e0b1c2b/EVE_SSO_Login_Buttons_Small_Black.png?w=195&h=30">|]
+asWidget (Custom a) = a
 
-instance FromJSON EveUser where
-    parseJSON = withObject "EveUser" $ \o -> EveUser
-        <$> o .: "CharacterName"
-        <*> o .: "ExpiresOn"
-        <*> o .: "TokenType"
-        <*> o .: "CharacterOwnerHash"
-        <*> o .: "CharacterID"
+pluginName :: Text
+pluginName = "eveonline"
 
-oauth2Eve :: YesodAuth m
-          => Text -- ^ Client ID
-          -> Text -- ^ Client Secret
-          -> WidgetType m
-          -> AuthPlugin m
-oauth2Eve clientId clientSecret = oauth2EveScoped clientId clientSecret ["publicData"] . asWidget
+defaultScopes :: [Text]
+defaultScopes = ["publicData"]
 
+oauth2Eve :: YesodAuth m => WidgetType m -> Text -> Text -> AuthPlugin m
+oauth2Eve = oauth2EveScoped defaultScopes
+
+oauth2EveScoped :: YesodAuth m => [Text] -> WidgetType m -> Text -> Text -> AuthPlugin m
+oauth2EveScoped scopes widgetType clientId clientSecret =
+    authOAuth2Widget (asWidget widgetType) pluginName oauth2 $ \manager token -> do
+        (User userId, userResponseJSON) <-
+            authGetProfile pluginName manager token "https://login.eveonline.com/oauth/verify"
+
+        pure Creds
+            { credsPlugin = "eveonline"
+            -- FIXME: Preserved bug. See similar comment in Bitbucket provider.
+            , credsIdent = T.pack $ show userId
+            , credsExtra =
+                [ ("accessToken", atoken $ accessToken token)
+                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
+                ]
+            }
   where
-    asWidget :: YesodAuth m => WidgetType m -> WidgetT m IO ()
-    asWidget Plain = [whamlet|Login via eveonline|]
-    asWidget BigWhite = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/4PTzeiAshqiM8osU2giO0Y/5cc4cb60bac52422da2e45db87b6819c/EVE_SSO_Login_Buttons_Large_White.png?w=270&h=45">|]
-    asWidget BigBlack = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/4fSjj56uD6CYwYyus4KmES/4f6385c91e6de56274d99496e6adebab/EVE_SSO_Login_Buttons_Large_Black.png?w=270&h=45">|]
-    asWidget SmallWhite = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/18BxKSXCymyqY4QKo8KwKe/c2bdded6118472dd587c8107f24104d7/EVE_SSO_Login_Buttons_Small_White.png?w=195&h=30">|]
-    asWidget SmallBlack = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/12vrPsIMBQi28QwCGOAqGk/33234da7672c6b0cdca394fc8e0b1c2b/EVE_SSO_Login_Buttons_Small_Black.png?w=195&h=30">|]
-    asWidget (Custom a) = a
-
-oauth2EveScoped :: YesodAuth m
-                => Text -- ^ Client ID
-                -> Text -- ^ Client Secret
-                -> [Text] -- ^ List of scopes to request
-                -> WidgetT m IO () -- ^ Login widget
-                -> AuthPlugin m
-oauth2EveScoped clientId clientSecret scopes widget =
-    authOAuth2Widget widget "eveonline" oauth fetchEveProfile
-
-  where
-    oauth = OAuth2
+    oauth2 = OAuth2
         { oauthClientId = clientId
         , oauthClientSecret = clientSecret
         , oauthOAuthorizeEndpoint = "https://login.eveonline.com/oauth/authorize" `withQuery`
@@ -79,24 +76,3 @@ oauth2EveScoped clientId clientSecret scopes widget =
         , oauthAccessTokenEndpoint = "https://login.eveonline.com/oauth/token"
         , oauthCallback = Nothing
         }
-
-fetchEveProfile :: Manager -> OAuth2Token -> IO (Creds m)
-fetchEveProfile manager token = do
-    userResult <- authGetJSON manager (accessToken token) "https://login.eveonline.com/oauth/verify"
-
-    case userResult of
-        Right user -> return $ toCreds user token
-        Left err-> throwIO $ invalidProfileResponse "eveonline" err
-
-toCreds :: EveUser -> OAuth2Token -> Creds m
-toCreds user token = Creds
-    { credsPlugin = "eveonline"
-    , credsIdent = T.pack $ show $ eveCharOwnerHash user
-    , credsExtra =
-        [ ("charName", eveUserName user)
-        , ("charId", T.pack . show . eveCharId $ user)
-        , ("tokenType", eveTokenType user)
-        , ("expires", eveUserExpire user)
-        , ("accessToken", atoken $ accessToken token)
-        ]
-    }

--- a/src/Yesod/Auth/OAuth2/EveOnline.hs
+++ b/src/Yesod/Auth/OAuth2/EveOnline.hs
@@ -52,14 +52,14 @@ oauth2Eve = oauth2EveScoped defaultScopes
 oauth2EveScoped :: YesodAuth m => [Text] -> WidgetType m -> Text -> Text -> AuthPlugin m
 oauth2EveScoped scopes widgetType clientId clientSecret =
     authOAuth2Widget (asWidget widgetType) pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token "https://login.eveonline.com/oauth/verify"
 
         pure Creds
             { credsPlugin = "eveonline"
             -- FIXME: Preserved bug. See similar comment in Bitbucket provider.
             , credsIdent = T.pack $ show userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/EveOnline.hs
+++ b/src/Yesod/Auth/OAuth2/EveOnline.hs
@@ -15,7 +15,6 @@ module Yesod.Auth.OAuth2.EveOnline
 
 import Yesod.Auth.OAuth2.Prelude
 
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import Yesod.Core.Widget
 
@@ -60,10 +59,7 @@ oauth2EveScoped scopes widgetType clientId clientSecret =
             { credsPlugin = "eveonline"
             -- FIXME: Preserved bug. See similar comment in Bitbucket provider.
             , credsIdent = T.pack $ show userId
-            , credsExtra =
-                [ ("accessToken", atoken $ accessToken token)
-                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
-                ]
+            , credsExtra = setExtra token userResponseJSON
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Github.hs
+++ b/src/Yesod/Auth/OAuth2/Github.hs
@@ -33,13 +33,13 @@ oauth2Github = oauth2GithubScoped defaultScopes
 oauth2GithubScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
 oauth2GithubScoped scopes clientId clientSecret =
     authOAuth2 pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token "https://api.github.com/user"
 
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = T.pack $ show userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Github.hs
+++ b/src/Yesod/Auth/OAuth2/Github.hs
@@ -14,52 +14,40 @@ module Yesod.Auth.OAuth2.Github
 
 import Yesod.Auth.OAuth2.Prelude
 
-import Data.List (find)
-import Data.Maybe (fromMaybe)
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 
-data GithubUser = GithubUser
-    { githubUserId :: Int
-    , githubUserName :: Maybe Text
-    , githubUserLogin :: Text
-    , githubUserAvatarUrl :: Text
-    , githubUserLocation :: Maybe Text
-    , githubUserPublicEmail :: Maybe Text
-    }
+newtype User = User Int
 
-instance FromJSON GithubUser where
-    parseJSON = withObject "GithubUser" $ \o -> GithubUser
+instance FromJSON User where
+    parseJSON = withObject "User" $ \o -> User
         <$> o .: "id"
-        <*> o .:? "name"
-        <*> o .: "login"
-        <*> o .: "avatar_url"
-        <*> o .:? "location"
-        <*> o .:? "email"
 
-data GithubUserEmail = GithubUserEmail
-    { githubUserEmailAddress :: Text
-    , githubUserEmailPrimary :: Bool
-    }
+pluginName :: Text
+pluginName = "github"
 
-instance FromJSON GithubUserEmail where
-    parseJSON = withObject "GithubUserEmail" $ \o -> GithubUserEmail
-        <$> o .: "email"
-        <*> o .: "primary"
+defaultScopes :: [Text]
+defaultScopes = ["user:email"]
 
-oauth2Github :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> AuthPlugin m
-oauth2Github clientId clientSecret = oauth2GithubScoped clientId clientSecret ["user:email"]
+oauth2Github :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2Github = oauth2GithubScoped defaultScopes
 
-oauth2GithubScoped :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> [Text] -- ^ List of scopes to request
-             -> AuthPlugin m
-oauth2GithubScoped clientId clientSecret scopes = authOAuth2 "github" oauth fetchGithubProfile
+oauth2GithubScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2GithubScoped scopes clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        (User userId, userResponseJSON) <-
+            authGetProfile pluginName manager token "https://api.github.com/user"
+
+        pure Creds
+            { credsPlugin = pluginName
+            , credsIdent = T.pack $ show userId
+            , credsExtra =
+                [ ("accessToken", atoken $ accessToken token)
+                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
+                ]
+            }
   where
-    oauth = OAuth2
+    oauth2 = OAuth2
         { oauthClientId = clientId
         , oauthClientSecret = clientSecret
         , oauthOAuthorizeEndpoint = "https://github.com/login/oauth/authorize" `withQuery`
@@ -68,32 +56,3 @@ oauth2GithubScoped clientId clientSecret scopes = authOAuth2 "github" oauth fetc
         , oauthAccessTokenEndpoint = "https://github.com/login/oauth/access_token"
         , oauthCallback = Nothing
         }
-
-fetchGithubProfile :: Manager -> OAuth2Token -> IO (Creds m)
-fetchGithubProfile manager token = do
-    userResult <- authGetJSON manager (accessToken token) "https://api.github.com/user"
-    mailResult <- authGetJSON manager (accessToken token) "https://api.github.com/user/emails"
-
-    case (userResult, mailResult) of
-        (Right _, Right []) -> throwIO $ InvalidProfileResponse "github" "no mail address for user"
-        (Right user, Right mails) -> return $ toCreds user mails token
-        (Left err, _) -> throwIO $ invalidProfileResponse "github" err
-        (_, Left err) -> throwIO $ invalidProfileResponse "github" err
-
-toCreds :: GithubUser -> [GithubUserEmail] -> OAuth2Token -> Creds m
-toCreds user userMails token = Creds
-    { credsPlugin = "github"
-    , credsIdent = T.pack $ show $ githubUserId user
-    , credsExtra =
-        [ ("email", githubUserEmailAddress email)
-        , ("login", githubUserLogin user)
-        , ("avatar_url", githubUserAvatarUrl user)
-        , ("access_token", atoken $ accessToken token)
-        ]
-        ++ maybeExtra "name" (githubUserName user)
-        ++ maybeExtra "public_email" (githubUserPublicEmail user)
-        ++ maybeExtra "location" (githubUserLocation user)
-    }
-
-  where
-    email = fromMaybe (head userMails) $ find githubUserEmailPrimary userMails

--- a/src/Yesod/Auth/OAuth2/Github.hs
+++ b/src/Yesod/Auth/OAuth2/Github.hs
@@ -5,7 +5,6 @@
 --
 -- * Authenticates against github
 -- * Uses github user id as credentials identifier
--- * Returns first_name, last_name, and email as extras
 --
 module Yesod.Auth.OAuth2.Github
     ( oauth2Github
@@ -14,7 +13,6 @@ module Yesod.Auth.OAuth2.Github
 
 import Yesod.Auth.OAuth2.Prelude
 
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 
 newtype User = User Int
@@ -41,10 +39,7 @@ oauth2GithubScoped scopes clientId clientSecret =
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = T.pack $ show userId
-            , credsExtra =
-                [ ("accessToken", atoken $ accessToken token)
-                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
-                ]
+            , credsExtra = setExtra token userResponseJSON
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Google.hs
+++ b/src/Yesod/Auth/OAuth2/Google.hs
@@ -6,24 +6,22 @@
 -- * Authenticates against Google
 -- * Uses Google user id as credentials identifier
 --
--- If you were previously relying on the ability to parse email as the creds
--- identifier, you can still do that by overriding it in the creds returned by
--- the plugin. For example:
+-- If you were previously relying on email as the creds identifier, you can
+-- still do that (and more) by overriding it in the creds returned by the plugin
+-- with any value read out of the new @userResponseJSON@ key in @'credsExtra'@.
 --
--- > --
--- > -- NOTE: proper use of Maybe/Either omitted for clarity.
--- > --
+-- For example:
+--
+-- > data User = User { userEmail :: Text }
 -- >
--- > parseEmail :: ByteString -> Text
--- > parseEmail = undefined
+-- > instance FromJSON User where -- you know...
 -- >
 -- > authenticate creds = do
--- >     let userResponseJSON = fromJust $ lookup "userResponseJSON" credsExtra creds
--- >         userEmail = parseEmail userResponseJSON
--- >         updatedCreds = creds { credsIdent = userEmail }
+-- >     -- 'getUserResponse' provided by "Yesod.Auth.OAuth" module
+-- >     let Right email = userEmail <$> getUserResponse creds
+-- >         updatedCreds = creds { credsIdent = email }
 -- >
 -- >     -- continue normally with updatedCreds
---
 --
 module Yesod.Auth.OAuth2.Google
     ( oauth2Google

--- a/src/Yesod/Auth/OAuth2/Google.hs
+++ b/src/Yesod/Auth/OAuth2/Google.hs
@@ -32,8 +32,6 @@ module Yesod.Auth.OAuth2.Google
 
 import Yesod.Auth.OAuth2.Prelude
 
-import qualified Data.ByteString.Lazy as BL
-
 newtype User = User Text
 
 instance FromJSON User where
@@ -59,10 +57,7 @@ oauth2GoogleScoped scopes clientId clientSecret =
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = userId
-            , credsExtra =
-                [ ("accessToken", atoken $ accessToken token)
-                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
-                ]
+            , credsExtra = setExtra token userResponseJSON
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Google.hs
+++ b/src/Yesod/Auth/OAuth2/Google.hs
@@ -8,7 +8,7 @@
 --
 -- If you were previously relying on email as the creds identifier, you can
 -- still do that (and more) by overriding it in the creds returned by the plugin
--- with any value read out of the new @userResponseJSON@ key in @'credsExtra'@.
+-- with any value read out of the new @userResponse@ key in @'credsExtra'@.
 --
 -- For example:
 --
@@ -17,8 +17,8 @@
 -- > instance FromJSON User where -- you know...
 -- >
 -- > authenticate creds = do
--- >     -- 'getUserResponse' provided by "Yesod.Auth.OAuth" module
--- >     let Right email = userEmail <$> getUserResponse creds
+-- >     -- 'getUserResponseJSON' provided by "Yesod.Auth.OAuth" module
+-- >     let Right email = userEmail <$> getUserResponseJSON creds
 -- >         updatedCreds = creds { credsIdent = email }
 -- >
 -- >     -- continue normally with updatedCreds
@@ -49,13 +49,13 @@ oauth2Google = oauth2GoogleScoped defaultScopes
 oauth2GoogleScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
 oauth2GoogleScoped scopes clientId clientSecret =
     authOAuth2 pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token "https://www.googleapis.com/oauth2/v3/userinfo"
 
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Google.hs
+++ b/src/Yesod/Auth/OAuth2/Google.hs
@@ -4,64 +4,68 @@
 -- OAuth2 plugin for http://www.google.com
 --
 -- * Authenticates against Google
--- * Uses Google user id or email as credentials identifier
--- * Returns given_name, family_name, email, and avatar_url as extras
+-- * Uses Google user id as credentials identifier
 --
--- Note: This may eventually replace Yesod.Auth.GoogleEmail2. Currently it
--- provides the same functionality except that GoogleEmail2 returns more profile
--- information.
+-- If you were previously relying on the ability to parse email as the creds
+-- identifier, you can still do that by overriding it in the creds returned by
+-- the plugin. For example:
+--
+-- > --
+-- > -- NOTE: proper use of Maybe/Either omitted for clarity.
+-- > --
+-- >
+-- > parseEmail :: ByteString -> Text
+-- > parseEmail = undefined
+-- >
+-- > authenticate creds = do
+-- >     let userResponseJSON = fromJust $ lookup "userResponseJSON" credsExtra creds
+-- >         userEmail = parseEmail userResponseJSON
+-- >         updatedCreds = creds { credsIdent = userEmail }
+-- >
+-- >     -- continue normally with updatedCreds
+--
 --
 module Yesod.Auth.OAuth2.Google
     ( oauth2Google
     , oauth2GoogleScoped
-    , oauth2GoogleScopedWithCustomId
-    , googleUid
-    , emailUid
     ) where
 
 import Yesod.Auth.OAuth2.Prelude
 
--- | Auth with Google
---
--- Requests @openid@ and @email@ scopes and uses email as the @'Creds'@
--- identifier.
---
-oauth2Google :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> AuthPlugin m
-oauth2Google = oauth2GoogleScoped ["openid", "email"]
+import qualified Data.ByteString.Lazy as BL
 
--- | Auth with Google
---
--- Requests custom scopes and uses email as the @'Creds'@ identifier.
---
-oauth2GoogleScoped :: YesodAuth m
-                   => [Text] -- ^ List of scopes to request
-                   -> Text -- ^ Client ID
-                   -> Text -- ^ Client Secret
-                   -> AuthPlugin m
-oauth2GoogleScoped = oauth2GoogleScopedWithCustomId emailUid
+newtype User = User Text
 
--- | Auth with Google
---
--- Requests custom scopes and uses the given function to create credentials
--- which allows for using any attribute as the identifier.
---
--- See @'emailUid'@ and @'googleUid'@.
---
-oauth2GoogleScopedWithCustomId :: YesodAuth m
-                               => (GoogleUser -> OAuth2Token -> Creds m)
-                               -- ^ A function to generate the credentials
-                               -> [Text] -- ^ List of scopes to request
-                               -> Text -- ^ Client ID
-                               -> Text -- ^ Client secret
-                               -> AuthPlugin m
-oauth2GoogleScopedWithCustomId toCreds scopes clientId clientSecret =
-    authOAuth2 "google" oauth $ fetchGoogleProfile toCreds
+instance FromJSON User where
+    parseJSON = withObject "User" $ \o -> User
+        -- Required for data backwards-compatibility
+        <$> (("google-uid:" <>) <$> o .: "sub")
 
+pluginName :: Text
+pluginName = "google"
+
+defaultScopes :: [Text]
+defaultScopes = ["openid", "email"]
+
+oauth2Google :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2Google = oauth2GoogleScoped defaultScopes
+
+oauth2GoogleScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2GoogleScoped scopes clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        (User userId, userResponseJSON) <-
+            authGetProfile pluginName manager token "https://www.googleapis.com/oauth2/v3/userinfo"
+
+        pure Creds
+            { credsPlugin = pluginName
+            , credsIdent = userId
+            , credsExtra =
+                [ ("accessToken", atoken $ accessToken token)
+                , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
+                ]
+            }
   where
-    oauth = OAuth2
+    oauth2 = OAuth2
         { oauthClientId = clientId
         , oauthClientSecret = clientSecret
         , oauthOAuthorizeEndpoint = "https://accounts.google.com/o/oauth2/auth" `withQuery`
@@ -70,53 +74,3 @@ oauth2GoogleScopedWithCustomId toCreds scopes clientId clientSecret =
         , oauthAccessTokenEndpoint = "https://www.googleapis.com/oauth2/v3/token"
         , oauthCallback = Nothing
         }
-
-fetchGoogleProfile :: (GoogleUser -> OAuth2Token -> Creds m) -> Manager -> OAuth2Token -> IO (Creds m)
-fetchGoogleProfile toCreds manager token = do
-    userInfo <- authGetJSON manager (accessToken token) "https://www.googleapis.com/oauth2/v3/userinfo"
-    case userInfo of
-      Right user -> return $ toCreds user token
-      Left err -> throwIO $ invalidProfileResponse "google" err
-
-data GoogleUser = GoogleUser
-    { googleUserId :: Text
-    , googleUserName :: Text
-    , googleUserEmail :: Text
-    , googleUserPicture :: Text
-    , googleUserGivenName :: Text
-    , googleUserFamilyName :: Text
-    , googleUserHostedDomain :: Maybe Text
-    }
-
-instance FromJSON GoogleUser where
-    parseJSON = withObject "GoogleUser" $ \o -> GoogleUser
-        <$> o .: "sub"
-        <*> o .: "name"
-        <*> o .: "email"
-        <*> o .: "picture"
-        <*> o .: "given_name"
-        <*> o .: "family_name"
-        <*> o .:? "hd"
-
--- | Build a @'Creds'@ using the user's google-uid as the identifier
-googleUid :: GoogleUser -> OAuth2Token -> Creds m
-googleUid = uidBuilder $ ("google-uid:" <>) . googleUserId
-
--- | Build a @'Creds'@ using the user's email as the identifier
-emailUid :: GoogleUser -> OAuth2Token -> Creds m
-emailUid = uidBuilder googleUserEmail
-
-uidBuilder :: (GoogleUser -> Text) -> GoogleUser -> OAuth2Token -> Creds m
-uidBuilder f user token = Creds
-    { credsPlugin = "google"
-    , credsIdent = f user
-    , credsExtra =
-        [ ("email", googleUserEmail user)
-        , ("name", googleUserName user)
-        , ("given_name", googleUserGivenName user)
-        , ("family_name", googleUserFamilyName user)
-        , ("avatar_url", googleUserPicture user)
-        , ("access_token", atoken $ accessToken token)
-        ]
-        ++ maybeExtra "hosted_domain" (googleUserHostedDomain user)
-    }

--- a/src/Yesod/Auth/OAuth2/Nylas.hs
+++ b/src/Yesod/Auth/OAuth2/Nylas.hs
@@ -7,7 +7,6 @@ module Yesod.Auth.OAuth2.Nylas
 import Yesod.Auth.OAuth2.Prelude
 
 import Control.Monad (unless)
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import Network.HTTP.Client
 import qualified Network.HTTP.Types as HT
@@ -44,10 +43,7 @@ oauth2Nylas clientId clientSecret =
             (\(User userId) -> pure Creds
                 { credsPlugin = pluginName
                 , credsIdent = userId
-                , credsExtra =
-                    [ ("accessToken", atoken $ accessToken token)
-                    , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
-                    ]
+                , credsExtra = setExtra token userResponseJSON
                 }
             )
             $ eitherDecode userResponseJSON

--- a/src/Yesod/Auth/OAuth2/Nylas.hs
+++ b/src/Yesod/Auth/OAuth2/Nylas.hs
@@ -29,13 +29,13 @@ oauth2Nylas clientId clientSecret =
         req <- applyBasicAuth (encodeUtf8 $ atoken $ accessToken token) ""
             <$> parseRequest "https://api.nylas.com/account"
         resp <- httpLbs req manager
-        let userResponseJSON = responseBody resp
+        let userResponse = responseBody resp
 
         -- FIXME: was this working? I'm 95% sure that the client will throw its
         -- own exception on unsuccessful status codes.
         unless (HT.statusIsSuccessful $ responseStatus resp)
             $ throwIO $ InvalidProfileResponse pluginName
-            $ "Unsuccessful HTTP response: " <> userResponseJSON
+            $ "Unsuccessful HTTP response: " <> userResponse
 
 
         either
@@ -43,10 +43,10 @@ oauth2Nylas clientId clientSecret =
             (\(User userId) -> pure Creds
                 { credsPlugin = pluginName
                 , credsIdent = userId
-                , credsExtra = setExtra token userResponseJSON
+                , credsExtra = setExtra token userResponse
                 }
             )
-            $ eitherDecode userResponseJSON
+            $ eitherDecode userResponse
   where
     oauth = OAuth2
         { oauthClientId = clientId

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -13,8 +13,8 @@ module Yesod.Auth.OAuth2.Prelude
 
     -- * Helpers
     , authGetProfile
+    , setExtra
     , scopeParam
-    , maybeExtra
 
     -- * Text
     , Text
@@ -123,6 +123,13 @@ fromAuthJSON :: FromJSON a => Text -> BL.ByteString -> IO a
 fromAuthJSON name =
     -- FIXME: unique exception constructors
     either (throwIO . InvalidProfileResponse name . BL8.pack) pure . eitherDecode
+
+-- | Construct (part of) @'credsExtra'@ container the token and user response
+setExtra :: OAuth2Token -> BL.ByteString -> [(Text, Text)]
+setExtra token userResponseJSON =
+    [ ("accessToken", atoken $ accessToken token)
+    , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
+    ]
 
 -- | Construct an @'InvalidProfileResponse'@ exception from an @'OAuth2Error'@
 --

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -117,10 +117,10 @@ scopeParam d = ("scope",) . encodeUtf8 . T.intercalate d
 -- Sets the following keys:
 --
 -- - @accessToken@: to support follow-up requests
--- - @userResponseJSON@: to support getting additional information
+-- - @userResponse@: to support getting additional information
 --
 setExtra :: OAuth2Token -> BL.ByteString -> [(Text, Text)]
-setExtra token userResponseJSON =
+setExtra token userResponse =
     [ ("accessToken", atoken $ accessToken token)
-    , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
+    , ("userResponse", decodeUtf8 $ BL.toStrict userResponse)
     ]

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -50,6 +50,7 @@ module Yesod.Auth.OAuth2.Prelude
     , Creds(..)
 
     -- * Bytestring URI types
+    , URI
     , Host(..)
 
     -- * Bytestring URI extensions

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -9,12 +9,11 @@
 --
 module Yesod.Auth.OAuth2.Prelude
     ( YesodOAuth2Exception(..)
-    , invalidProfileResponse
 
-    -- * Helpers
+    -- * Provider helpers
     , authGetProfile
-    , setExtra
     , scopeParam
+    , setExtra
 
     -- * Text
     , Text
@@ -33,7 +32,6 @@ module Yesod.Auth.OAuth2.Prelude
 
     -- * Exceptions
     , throwIO
-    , tryIO
 
     -- * OAuth2
     , OAuth2(..)
@@ -59,11 +57,6 @@ module Yesod.Auth.OAuth2.Prelude
     -- * Temporary, until I finish re-structuring modules
     , authOAuth2
     , authOAuth2Widget
-
-    -- * Deprecated, until everything's moved over to @'authGetProfile'@
-    , authGetJSON
-    , fromProfileURL
-    , maybeExtra
     ) where
 
 import Control.Exception.Safe
@@ -95,20 +88,10 @@ instance Exception YesodOAuth2Exception
 -- | Retrieve a user's profile as JSON
 --
 -- The response should be parsed only far enough to read the required
--- @'credsIdent'@. The raw response is returned as well, to be set in
--- @'credsExtra'@for consumers to re-use if information they seek is in the
--- response already.
+-- @'credsIdent'@. Additional information should either be re-parsed by or
+-- fetched via additional requests by consumers.
 --
--- Information requiring other requests should use the access token (also in
--- @'credsExtra'@ to make subsequent requests themselves.
---
-authGetProfile
-    :: FromJSON a
-    => Text -- ^ Plugin name
-    -> Manager
-    -> OAuth2Token
-    -> URI
-    -> IO (a, BL.ByteString)
+authGetProfile :: FromJSON a => Text -> Manager -> OAuth2Token -> URI -> IO (a, BL.ByteString)
 authGetProfile name manager token url = do
     resp <- fromAuthGet name =<< authGetBS manager (accessToken token) url
     decoded <- fromAuthJSON name resp
@@ -117,7 +100,7 @@ authGetProfile name manager token url = do
 -- | Throws a @Left@ result as an @'InvalidProfileResponse'@
 fromAuthGet :: Text -> Either (OAuth2Error Value) BL.ByteString -> IO BL.ByteString
 fromAuthGet _ (Right bs) = pure bs -- nice
-fromAuthGet name (Left err) = throwIO $ invalidProfileResponse name err
+fromAuthGet name (Left err) = throwIO $ InvalidProfileResponse name $ encode err
 
 -- | Throws a decoding error as an @'InvalidProfileResponse'@
 fromAuthJSON :: FromJSON a => Text -> BL.ByteString -> IO a
@@ -125,38 +108,19 @@ fromAuthJSON name =
     -- FIXME: unique exception constructors
     either (throwIO . InvalidProfileResponse name . BL8.pack) pure . eitherDecode
 
--- | Construct (part of) @'credsExtra'@ container the token and user response
+-- | A tuple of @\"scope\"@ and the given scopes separated by a delimiter
+scopeParam :: Text -> [Text] -> (ByteString, ByteString)
+scopeParam d = ("scope",) . encodeUtf8 . T.intercalate d
+
+-- | Construct part of @'credsExtra'@
+--
+-- Sets the following keys:
+--
+-- - @accessToken@: to support follow-up requests
+-- - @userResponseJSON@: to support getting additional information
+--
 setExtra :: OAuth2Token -> BL.ByteString -> [(Text, Text)]
 setExtra token userResponseJSON =
     [ ("accessToken", atoken $ accessToken token)
     , ("userResponseJSON", decodeUtf8 $ BL.toStrict userResponseJSON)
     ]
-
--- | Construct an @'InvalidProfileResponse'@ exception from an @'OAuth2Error'@
---
--- This forces the @e@ in @'OAuth2Error' e@ to parse as a JSON @'Value'@ which
--- is then re-encoded for the exception message.
---
--- Deprecated.
---
-invalidProfileResponse :: Text -> OAuth2Error Value -> YesodOAuth2Exception
-invalidProfileResponse name = InvalidProfileResponse name . encode
-
--- | Handle the common case of fetching Profile information from a JSON endpoint
---
--- Throws @'InvalidProfileResponse'@ if JSON parsing fails
---
--- Deprecated.
---
-fromProfileURL :: FromJSON a => Text -> URI -> (a -> Creds m) -> FetchCreds m
-fromProfileURL name url toCreds manager token =
-    toCreds . fst <$> authGetProfile name manager token url
-
--- | A tuple of @scope@ and the given scopes separated by a delimiter
-scopeParam :: Text -> [Text] -> (ByteString, ByteString)
-scopeParam d = ("scope",) . encodeUtf8 . T.intercalate d
-
--- | A helper for providing an optional value to credsExtra
-maybeExtra :: Text -> Maybe Text -> [(Text, Text)]
-maybeExtra k (Just v) = [(k, v)]
-maybeExtra _ Nothing  = []

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -62,13 +62,14 @@ module Yesod.Auth.OAuth2.Prelude
     -- * Deprecated, until everything's moved over to @'authGetProfile'@
     , authGetJSON
     , fromProfileURL
+    , maybeExtra
     ) where
 
 import Control.Exception.Safe
 import Data.Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Lazy.Char8 as BSL8
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BL8
 import Data.Semigroup ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -86,7 +87,7 @@ import Yesod.Auth.OAuth2
 --
 -- Deprecated. Eventually, we'll return @Either@s all the way up.
 --
-data YesodOAuth2Exception = InvalidProfileResponse Text BSL.ByteString
+data YesodOAuth2Exception = InvalidProfileResponse Text BL.ByteString
     deriving (Show, Typeable)
 instance Exception YesodOAuth2Exception
 
@@ -106,22 +107,22 @@ authGetProfile
     -> Manager
     -> OAuth2Token
     -> URI
-    -> IO (a, BSL.ByteString)
+    -> IO (a, BL.ByteString)
 authGetProfile name manager token url = do
     resp <- fromAuthGet name =<< authGetBS manager (accessToken token) url
     decoded <- fromAuthJSON name resp
     pure (decoded, resp)
 
 -- | Throws a @Left@ result as an @'InvalidProfileResponse'@
-fromAuthGet :: Text -> Either (OAuth2Error Value) BSL.ByteString -> IO BSL.ByteString
+fromAuthGet :: Text -> Either (OAuth2Error Value) BL.ByteString -> IO BL.ByteString
 fromAuthGet _ (Right bs) = pure bs -- nice
 fromAuthGet name (Left err) = throwIO $ invalidProfileResponse name err
 
 -- | Throws a decoding error as an @'InvalidProfileResponse'@
-fromAuthJSON :: FromJSON a => Text -> BSL.ByteString -> IO a
+fromAuthJSON :: FromJSON a => Text -> BL.ByteString -> IO a
 fromAuthJSON name =
     -- FIXME: unique exception constructors
-    either (throwIO . InvalidProfileResponse name . BSL8.pack) pure . eitherDecode
+    either (throwIO . InvalidProfileResponse name . BL8.pack) pure . eitherDecode
 
 -- | Construct an @'InvalidProfileResponse'@ exception from an @'OAuth2Error'@
 --

--- a/src/Yesod/Auth/OAuth2/Salesforce.hs
+++ b/src/Yesod/Auth/OAuth2/Salesforce.hs
@@ -57,12 +57,12 @@ salesforceHelper
     -> AuthPlugin m
 salesforceHelper name profileUri authorizeUri tokenUri scopes clientId clientSecret =
     authOAuth2 name oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <- authGetProfile name manager token profileUri
+        (User userId, userResponse) <- authGetProfile name manager token profileUri
 
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Salesforce.hs
+++ b/src/Yesod/Auth/OAuth2/Salesforce.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 -- |
 --
 -- OAuth2 plugin for http://login.salesforce.com
 --
--- * Authenticates against Salesforce
+-- * Authenticates against Salesforce (or sandbox)
 -- * Uses Salesforce user id as credentials identifier
--- * Returns given_name, family_name, email and avatar_url as extras
 --
 module Yesod.Auth.OAuth2.Salesforce
     ( oauth2Salesforce
@@ -17,124 +15,60 @@ module Yesod.Auth.OAuth2.Salesforce
 
 import Yesod.Auth.OAuth2.Prelude
 
-import qualified Data.Text as T
-
-oauth2Salesforce :: YesodAuth m
-                 => Text -- ^ Client ID
-                 -> Text -- ^ Client Secret
-                 -> AuthPlugin m
-oauth2Salesforce = oauth2SalesforceScoped ["openid", "email", "api"]
-
-svcName :: Text
-svcName = "salesforce"
-
-oauth2SalesforceScoped :: YesodAuth m
-                       => [Text] -- ^ List of scopes to request
-                       -> Text -- ^ Client ID
-                       -> Text -- ^ Client Secret
-                       -> AuthPlugin m
-oauth2SalesforceScoped scopes clientId clientSecret =
-    authOAuth2 svcName oauth fetchSalesforceUser
-  where
-    oauth = OAuth2
-        { oauthClientId            = clientId
-        , oauthClientSecret        = clientSecret
-        , oauthOAuthorizeEndpoint  = "https://login.salesforce.com/services/oauth2/authorize" `withQuery`
-            [ scopeParam " " scopes
-            ]
-        , oauthAccessTokenEndpoint = "https://login.salesforce.com/services/oauth2/token"
-        , oauthCallback            = Nothing
-        }
-
-fetchSalesforceUser :: Manager -> OAuth2Token -> IO (Creds m)
-fetchSalesforceUser manager token = do
-    result <- authGetJSON manager (accessToken token) "https://login.salesforce.com/services/oauth2/userinfo"
-    case result of
-        Right user -> return $ toCreds svcName user token
-        Left err -> throwIO $ invalidProfileResponse svcName err
-
-svcNameSb :: Text
-svcNameSb = "salesforce-sandbox"
-
-oauth2SalesforceSandbox :: YesodAuth m
-                        => Text -- ^ Client ID
-                        -> Text -- ^ Client Secret
-                        -> AuthPlugin m
-oauth2SalesforceSandbox = oauth2SalesforceSandboxScoped ["openid", "email"]
-
-
-oauth2SalesforceSandboxScoped :: YesodAuth m
-                              => [Text] -- ^ List of scopes to request
-                              -> Text -- ^ Client ID
-                              -> Text -- ^ Client Secret
-                              -> AuthPlugin m
-oauth2SalesforceSandboxScoped scopes clientId clientSecret =
-    authOAuth2 svcNameSb oauth fetchSalesforceSandboxUser
-  where
-    oauth = OAuth2
-        { oauthClientId            = clientId
-        , oauthClientSecret        = clientSecret
-        , oauthOAuthorizeEndpoint  = "https://test.salesforce.com/services/oauth2/authorize" `withQuery`
-            [ scopeParam " " scopes
-            ]
-        , oauthAccessTokenEndpoint = "https://test.salesforce.com/services/oauth2/token"
-        , oauthCallback            = Nothing
-        }
-
-fetchSalesforceSandboxUser :: Manager -> OAuth2Token -> IO (Creds m)
-fetchSalesforceSandboxUser manager token = do
-    result <- authGetJSON manager (accessToken token) "https://test.salesforce.com/services/oauth2/userinfo"
-    case result of
-        Right user -> return $ toCreds svcNameSb user token
-        Left err -> throwIO $ invalidProfileResponse svcNameSb err
-
-data User = User
-    { userId :: Text
-    , userOrg :: Text
-    , userNickname :: Text
-    , userName :: Text
-    , userGivenName :: Text
-    , userFamilyName :: Text
-    , userTimeZone :: Text
-    , userEmail :: Text
-    , userPicture :: Text
-    , userPhone :: Maybe Text
-    , userRestUrl :: Text
-    }
+newtype User = User Text
 
 instance FromJSON User where
-    parseJSON = withObject "User" $ \o -> do
-        userId          <- o .: "user_id"
-        userOrg         <- o .: "organization_id"
-        userNickname    <- o .: "nickname"
-        userName        <- o .: "name"
-        userGivenName   <- o .: "given_name"
-        userFamilyName  <- o .: "family_name"
-        userTimeZone    <- o .: "zoneinfo"
-        userEmail       <- o .: "email"
-        userPicture     <- o .: "picture"
-        userPhone       <- o .:? "phone_number"
-        urls            <- o .: "urls"
-        userRestUrl     <- urls .: "rest"
-        return User{..}
+    parseJSON = withObject "User" $ \o -> User
+        <$> o .: "user_id"
 
-toCreds :: Text -> User -> OAuth2Token -> Creds m
-toCreds name user token = Creds
-    { credsPlugin = name
-    , credsIdent = userId user
-    , credsExtra =
-        [ ("email", userEmail user)
-        , ("org", userOrg user)
-        , ("nickname", userName user)
-        , ("name", userName user)
-        , ("given_name", userGivenName user)
-        , ("family_name", userFamilyName user)
-        , ("time_zone", userTimeZone user)
-        , ("avatar_url", userPicture user)
-        , ("rest_url", userRestUrl user)
-        , ("access_token", atoken $ accessToken token)
-        ]
-        ++ maybeExtra "refresh_token" (rtoken <$> refreshToken token)
-        ++ maybeExtra "expires_in" (T.pack . show <$> expiresIn token)
-        ++ maybeExtra "phone_number" (userPhone user)
-    }
+pluginName :: Text
+pluginName = "salesforce"
+
+defaultScopes :: [Text]
+defaultScopes = ["openid", "email", "api"]
+
+oauth2Salesforce :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2Salesforce = oauth2SalesforceScoped defaultScopes
+
+oauth2SalesforceScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2SalesforceScoped = salesforceHelper pluginName
+    "https://login.salesforce.com/services/oauth2/userinfo"
+    "https://login.salesforce.com/services/oauth2/authorize"
+    "https://login.salesforce.com/services/oauth2/token"
+
+oauth2SalesforceSandbox :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2SalesforceSandbox = oauth2SalesforceSandboxScoped defaultScopes
+
+oauth2SalesforceSandboxScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2SalesforceSandboxScoped = salesforceHelper (pluginName <> "-sandbox")
+    "https://test.salesforce.com/services/oauth2/userinfo"
+    "https://test.salesforce.com/services/oauth2/authorize"
+    "https://test.salesforce.com/services/oauth2/token"
+
+salesforceHelper
+    :: YesodAuth m
+    => Text
+    -> URI -- ^ User profile
+    -> URI -- ^ Authorize
+    -> URI -- ^ Token
+    -> [Text]
+    -> Text
+    -> Text
+    -> AuthPlugin m
+salesforceHelper name profileUri authorizeUri tokenUri scopes clientId clientSecret =
+    authOAuth2 name oauth2 $ \manager token -> do
+        (User userId, userResponseJSON) <- authGetProfile name manager token profileUri
+
+        pure Creds
+            { credsPlugin = pluginName
+            , credsIdent = userId
+            , credsExtra = setExtra token userResponseJSON
+            }
+  where
+    oauth2 = OAuth2
+        { oauthClientId = clientId
+        , oauthClientSecret = clientSecret
+        , oauthOAuthorizeEndpoint = authorizeUri `withQuery` [scopeParam " " scopes]
+        , oauthAccessTokenEndpoint = tokenUri
+        , oauthCallback = Nothing
+        }

--- a/src/Yesod/Auth/OAuth2/Slack.hs
+++ b/src/Yesod/Auth/OAuth2/Slack.hs
@@ -50,17 +50,17 @@ oauth2SlackScoped scopes clientId clientSecret =
         let param = encodeUtf8 $ atoken $ accessToken token
         req <- setQueryString [("token", Just param)]
             <$> parseUrlThrow "https://slack.com/api/users.identity"
-        userResponseJSON <- responseBody <$> httpLbs req manager
+        userResponse <- responseBody <$> httpLbs req manager
 
         either
-            (const $ throwIO $ InvalidProfileResponse pluginName userResponseJSON)
+            (const $ throwIO $ InvalidProfileResponse pluginName userResponse)
             (\(User userId) -> pure Creds
                 { credsPlugin = pluginName
                 , credsIdent = userId
-                , credsExtra = setExtra token userResponseJSON
+                , credsExtra = setExtra token userResponse
                 }
             )
-            $ eitherDecode userResponseJSON
+            $ eitherDecode userResponse
   where
     oauth2 = OAuth2
         { oauthClientId = clientId

--- a/src/Yesod/Auth/OAuth2/Slack.hs
+++ b/src/Yesod/Auth/OAuth2/Slack.hs
@@ -4,7 +4,6 @@
 --
 -- * Authenticates against slack
 -- * Uses slack user id as credentials identifier
--- * Returns name, access_token, email, avatar, team_id, and team_name as extras
 --
 module Yesod.Auth.OAuth2.Slack
     ( SlackScope(..)
@@ -14,103 +13,61 @@ module Yesod.Auth.OAuth2.Slack
 
 import Yesod.Auth.OAuth2.Prelude
 
-import Data.Maybe (catMaybes)
-import qualified Network.HTTP.Conduit as HTTP
+import Network.HTTP.Client
+    (httpLbs, parseUrlThrow, responseBody, setQueryString)
 
 data SlackScope
-    = SlackEmailScope
+    = SlackBasicScope
+    | SlackEmailScope
     | SlackTeamScope
     | SlackAvatarScope
 
-data SlackUser = SlackUser
-    { slackUserId :: Text
-    , slackUserName :: Text
-    , slackUserEmail :: Maybe Text
-    , slackUserAvatarUrl :: Maybe Text
-    , slackUserTeam :: Maybe SlackTeam
-    }
-
-data SlackTeam = SlackTeam
-    { slackTeamId :: Text
-    , slackTeamName :: Text
-    }
-
-instance FromJSON SlackUser where
-    parseJSON = withObject "root" $ \root -> do
-        user <- root .: "user"
-
-        SlackUser
-            <$> user .: "id"
-            <*> user .: "name"
-            <*> user .:? "email"
-            <*> user .:? "image_512"
-            <*> root .:? "team"
-
-instance FromJSON SlackTeam where
-    parseJSON = withObject "team" $ \team ->
-        SlackTeam
-            <$> team .: "id"
-            <*> team .: "name"
-
--- | Auth with Slack
---
--- Requests @identity.basic@ scopes and uses the user's Slack ID as the @'Creds'@
--- identifier.
---
-oauth2Slack :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> AuthPlugin m
-oauth2Slack clientId clientSecret = oauth2SlackScoped clientId clientSecret []
-
--- | Auth with Slack
---
--- Requests custom scopes and uses the user's Slack ID as the @'Creds'@
--- identifier.
---
-oauth2SlackScoped :: YesodAuth m
-             => Text -- ^ Client ID
-             -> Text -- ^ Client Secret
-             -> [SlackScope]
-             -> AuthPlugin m
-oauth2SlackScoped clientId clientSecret scopes =
-    authOAuth2 "slack" oauth fetchSlackProfile
-  where
-    oauth = OAuth2
-        { oauthClientId = clientId
-        , oauthClientSecret = clientSecret
-        , oauthOAuthorizeEndpoint = "https://slack.com/oauth/authorize" `withQuery`
-            [ scopeParam "," $ "identity.basic" : map scopeText scopes
-            ]
-        , oauthAccessTokenEndpoint = "https://slack.com/api/oauth.access"
-        , oauthCallback = Nothing
-        }
-
 scopeText :: SlackScope -> Text
+scopeText SlackBasicScope = "identity.basic"
 scopeText SlackEmailScope = "identity.email"
 scopeText SlackTeamScope = "identity.team"
 scopeText SlackAvatarScope = "identity.avatar"
 
-fetchSlackProfile :: Manager -> OAuth2Token -> IO (Creds m)
-fetchSlackProfile manager token = do
-    request
-        <- HTTP.setQueryString [("token", Just $ encodeUtf8 $ atoken $ accessToken token)]
-        <$> HTTP.parseUrlThrow "https://slack.com/api/users.identity"
-    body <- HTTP.responseBody <$> HTTP.httpLbs request manager
-    case eitherDecode body of
-        Left _ -> throwIO $ InvalidProfileResponse "slack" body
-        Right u -> return $ toCreds u token
+newtype User = User Text
 
-toCreds :: SlackUser -> OAuth2Token -> Creds m
-toCreds user token = Creds
-    { credsPlugin = "slack"
-    , credsIdent = slackUserId user
-    , credsExtra = catMaybes
-        [ Just ("name", slackUserName user)
-        , Just ("access_token", atoken $ accessToken token)
-        , (,) <$> pure "email" <*> slackUserEmail user
-        , (,) <$> pure "avatar" <*> slackUserAvatarUrl user
-        , (,) <$> pure "team_name" <*> (slackTeamName <$> slackUserTeam user)
-        , (,) <$> pure "team_id" <*> (slackTeamId <$> slackUserTeam user)
-        ]
-    }
+instance FromJSON User where
+    parseJSON = withObject "User" $ \root -> do
+        o <- root .: "user"
+        User <$> o .: "id"
+
+pluginName :: Text
+pluginName = "slack"
+
+defaultScopes :: [SlackScope]
+defaultScopes = [SlackBasicScope]
+
+oauth2Slack :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2Slack = oauth2SlackScoped defaultScopes
+
+oauth2SlackScoped :: YesodAuth m => [SlackScope] -> Text -> Text -> AuthPlugin m
+oauth2SlackScoped scopes clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        let param = encodeUtf8 $ atoken $ accessToken token
+        req <- setQueryString [("token", Just param)]
+            <$> parseUrlThrow "https://slack.com/api/users.identity"
+        userResponseJSON <- responseBody <$> httpLbs req manager
+
+        either
+            (const $ throwIO $ InvalidProfileResponse pluginName userResponseJSON)
+            (\(User userId) -> pure Creds
+                { credsPlugin = pluginName
+                , credsIdent = userId
+                , credsExtra = setExtra token userResponseJSON
+                }
+            )
+            $ eitherDecode userResponseJSON
+  where
+    oauth2 = OAuth2
+        { oauthClientId = clientId
+        , oauthClientSecret = clientSecret
+        , oauthOAuthorizeEndpoint = "https://slack.com/oauth/authorize" `withQuery`
+            [ scopeParam "," $ map scopeText scopes
+            ]
+        , oauthAccessTokenEndpoint = "https://slack.com/api/oauth.access"
+        , oauthCallback = Nothing
+        }

--- a/src/Yesod/Auth/OAuth2/Spotify.hs
+++ b/src/Yesod/Auth/OAuth2/Spotify.hs
@@ -21,13 +21,13 @@ pluginName = "spotify"
 oauth2Spotify :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
 oauth2Spotify scopes clientId clientSecret =
     authOAuth2 pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token "https://api.spotify.com/v1/me"
 
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2

--- a/src/Yesod/Auth/OAuth2/Spotify.hs
+++ b/src/Yesod/Auth/OAuth2/Spotify.hs
@@ -9,84 +9,33 @@ module Yesod.Auth.OAuth2.Spotify
 
 import Yesod.Auth.OAuth2.Prelude
 
-import Data.Maybe
-import qualified Data.Text as T
+newtype User = User Text
 
-data SpotifyUserImage = SpotifyUserImage
-    { spotifyUserImageHeight :: Maybe Int
-    , spotifyUserImageWidth :: Maybe Int
-    , spotifyUserImageUrl :: Text
-    }
+instance FromJSON User where
+    parseJSON = withObject "User" $ \o -> User
+        <$> o .: "id"
 
-instance FromJSON SpotifyUserImage where
-    parseJSON = withObject "SpotifyUserImage" $ \v -> SpotifyUserImage
-        <$> v .:? "height"
-        <*> v .:? "width"
-        <*> v .: "url"
+pluginName :: Text
+pluginName = "spotify"
 
-data SpotifyUser = SpotifyUser
-    { spotifyUserId :: Text
-    , spotifyUserHref :: Text
-    , spotifyUserUri :: Text
-    , spotifyUserDisplayName :: Maybe Text
-    , spotifyUserProduct :: Maybe Text
-    , spotifyUserCountry :: Maybe Text
-    , spotifyUserEmail :: Maybe Text
-    , spotifyUserImages :: Maybe [SpotifyUserImage]
-    }
+oauth2Spotify :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2Spotify scopes clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        (User userId, userResponseJSON) <-
+            authGetProfile pluginName manager token "https://api.spotify.com/v1/me"
 
-instance FromJSON SpotifyUser where
-    parseJSON = withObject "SpotifyUser" $ \v -> SpotifyUser
-        <$> v .: "id"
-        <*> v .: "href"
-        <*> v .: "uri"
-        <*> v .:? "display_name"
-        <*> v .:? "product"
-        <*> v .:? "country"
-        <*> v .:? "email"
-        <*> v .:? "images"
-
-oauth2Spotify :: YesodAuth m
-              => Text -- ^ Client ID
-              -> Text -- ^ Client Secret
-              -> [Text] -- ^ Scopes
-              -> AuthPlugin m
-oauth2Spotify clientId clientSecret scope = authOAuth2 "spotify"
-    OAuth2
+        pure Creds
+            { credsPlugin = pluginName
+            , credsIdent = userId
+            , credsExtra = setExtra token userResponseJSON
+            }
+  where
+    oauth2 = OAuth2
         { oauthClientId = clientId
         , oauthClientSecret = clientSecret
         , oauthOAuthorizeEndpoint = "https://accounts.spotify.com/authorize" `withQuery`
-            [ ("scope", encodeUtf8 $ T.intercalate " " scope)
+            [ scopeParam " " scopes
             ]
         , oauthAccessTokenEndpoint = "https://accounts.spotify.com/api/token"
         , oauthCallback = Nothing
         }
-    $ fromProfileURL "spotify" "https://api.spotify.com/v1/me" toCreds
-
-toCreds :: SpotifyUser -> Creds m
-toCreds user = Creds
-    { credsPlugin = "spotify"
-    , credsIdent = spotifyUserId user
-    , credsExtra = mapMaybe getExtra extrasTemplate
-    }
-
-  where
-    userImage :: Maybe SpotifyUserImage
-    userImage = spotifyUserImages user >>= listToMaybe
-
-    userImagePart :: (SpotifyUserImage -> Maybe a) -> Maybe a
-    userImagePart getter = userImage >>= getter
-
-    extrasTemplate = [ ("href", Just $ spotifyUserHref user)
-                     , ("uri", Just $ spotifyUserUri user)
-                     , ("display_name", spotifyUserDisplayName user)
-                     , ("product", spotifyUserProduct user)
-                     , ("country", spotifyUserCountry user)
-                     , ("email", spotifyUserEmail user)
-                     , ("image_url", spotifyUserImageUrl <$> userImage)
-                     , ("image_height", T.pack . show <$> userImagePart spotifyUserImageHeight)
-                     , ("image_width", T.pack . show <$> userImagePart spotifyUserImageWidth)
-                     ]
-
-    getExtra :: (Text, Maybe Text) -> Maybe (Text, Text)
-    getExtra (key, val) = fmap ((,) key) val

--- a/src/Yesod/Auth/OAuth2/Upcase.hs
+++ b/src/Yesod/Auth/OAuth2/Upcase.hs
@@ -27,13 +27,13 @@ pluginName = "upcase"
 oauth2Upcase :: YesodAuth m => Text -> Text -> AuthPlugin m
 oauth2Upcase clientId clientSecret =
     authOAuth2 pluginName oauth2 $ \manager token -> do
-        (User userId, userResponseJSON) <-
+        (User userId, userResponse) <-
             authGetProfile pluginName manager token "http://upcase.com/api/v1/me.json"
 
         pure Creds
             { credsPlugin = pluginName
             , credsIdent = T.pack $ show userId
-            , credsExtra = setExtra token userResponseJSON
+            , credsExtra = setExtra token userResponse
             }
   where
     oauth2 = OAuth2


### PR DESCRIPTION
See #71.

New `credsExtra` keys:

- `accessToken`: so you can make your own follow-up requests
- `userResponseJSON`: so you can get more information out of the request
  we already made (you just have to parse it yourself)

Removed keys:

- `access_token`: renamed to `accessToken`
- `avatar_url`: can be re-parsed
- `email`: requires your own request to `/emails`
- `login`: can be re-parsed from `userResponseJSON`
- `location`: can be re-parsed, was not always present
- `name`: can be re-parse, was not not always present
- `public_email`: can be re-parsed, was not not always present

---

I'll start going provider by provider now.