### PR TITLE
Officially drop 7.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,6 @@ references:
             fi
 
 jobs:
-  build_7.10.3:
-    <<: *stack_build
-    environment:
-      STACK_ARGUMENTS: --resolver lts-6.35
   build_8.0.2:
     <<: *stack_build
     environment:
@@ -67,8 +63,6 @@ workflows:
   version: 2
   builds:
     jobs:
-      # FIXME: https://circleci.com/gh/thoughtbot/yesod-auth-oauth2/113
-      # - build_7.10.3
       - build_8.0.2
       - build_8.2.2
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ jobs:
     <<: *stack_build
     environment:
       STACK_ARGUMENTS: --resolver lts-10.3
+  build:
+    <<: *stack_build
   build_nightly:
     <<: *stack_build
     environment:
@@ -69,4 +71,5 @@ workflows:
       # - build_7.10.3
       - build_8.0.2
       - build_8.2.2
+      - build
       - build_nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - [PR](https://github.com/thoughtbot/yesod-auth-oauth2/pull/100)
 
 - COMPATIBILITY: Support GHC-8.2
-- COMPATIBILITY: Drop support for GHC-7.8
+- COMPATIBILITY: Drop (claimed, but never tested) support for GHC-7.8 & 7.10
 - LICENSE: fixed vague licensing (MIT now)
 
 ## [v0.3.1](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.3.0...v0.3.1)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ all: setup build test lint
 .PHONY: setup
 setup:
 	stack setup $(STACK_ARGUMENTS)
-	stack build $(STACK_ARGUMENTS) --dependencies-only --test --no-run-tests
+	stack build $(STACK_ARGUMENTS) \
+	  --flag yesod-auth-oauth2:example \
+	  --dependencies-only --test --no-run-tests
 	stack install $(STACK_ARGUMENTS) hlint weeder
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ build:
 
 .PHONY: test
 test:
-	stack build $(STACK_ARGUMENTS) --test
+	stack build $(STACK_ARGUMENTS) \
+	  --flag yesod-auth-oauth2:example \
+	  --pedantic --test
 
 
 .PHONY: lint

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,7 @@ homepage: http://github.com/thoughtbot/yesod-auth-oauth2
 ghc-options: -Wall
 
 dependencies:
-  - base >=4.8.0.0 && <5
+  - base >=4.9.0.0 && <5
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 ---
-resolver: lts-10.3
+resolver: lts-10.7
 
 ghc-options:
    "$locals": -fhide-source-paths


### PR DESCRIPTION
In an attempt to get CI to assert it actually worked, I've decided, after many
rounds of extra-deps fighting, that it's either impossible or difficult enough
to give up.

So (among other minor CI tweaks), this set of patches removes the disabled 7.10
CI job and sets the base versions bounds, thus making it official.