### PR TITLE
Update LTS and dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   build_8.2.2:
     <<: *stack_build
     environment:
-      STACK_ARGUMENTS: --stack-yaml stack-lts-10.3.yaml
+      STACK_ARGUMENTS: --stack-yaml stack-lts-11.5.yaml
   build:
     <<: *stack_build
   build_nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
   build_nightly:
     <<: *stack_build
     environment:
-      STACK_ARGUMENTS: --resolver nightly
+      STACK_ARGUMENTS: --stack-yaml stack-nightly.yaml
 
 workflows:
   version: 2
@@ -66,4 +66,4 @@ workflows:
       # - build_8.0.2
       - build_8.2.2
       - build
-      # - build_nightly  # hoauth2
+      - build_nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   build_8.2.2:
     <<: *stack_build
     environment:
-      STACK_ARGUMENTS: --resolver lts-10.3
+      STACK_ARGUMENTS: --stack-yaml stack-lts-10.3.yaml
   build:
     <<: *stack_build
   build_nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
   build_nightly:
     <<: *stack_build
     environment:
-      STACK_ARGUMENTS: --stack-yaml stack-nightly.yaml
+      STACK_ARGUMENTS: --resolver nightly --stack-yaml stack-nightly.yaml
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ workflows:
   version: 2
   builds:
     jobs:
-      - build_8.0.2
+      # - build_8.0.2
       - build_8.2.2
       - build
       # - build_nightly  # hoauth2

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -78,7 +78,6 @@ instance YesodAuth App where
 
         return $ Authenticated "1"
 
-    authHttpManager = appHttpManager
     authPlugins = appAuthPlugins
 
 instance RenderMessage App FormMessage where

--- a/package.yaml
+++ b/package.yaml
@@ -21,7 +21,7 @@ library:
     - aeson >=0.6 && <1.4
     - bytestring >=0.9.1.4
     - errors
-    - hoauth2 >=1.3.0 && <1.6
+    - hoauth2 >=1.3.0 && <1.8
     - http-client >=0.4.0 && <0.6
     - http-conduit >=2.0 && <3.0
     - http-types >=0.8 && <0.13
@@ -31,8 +31,8 @@ library:
     - text >=0.7 && <2.0
     - transformers >=0.2.2 && <0.6
     - uri-bytestring
-    - yesod-auth >=1.3 && <1.5
-    - yesod-core >=1.2 && <1.5
+    - yesod-auth >=1.6.0 && <1.7
+    - yesod-core >=1.6.0 && <1.7
 
 executables:
   yesod-auth-oauth2-example:

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,6 @@ library:
     - random
     - safe-exceptions
     - text >=0.7 && <2.0
-    - transformers >=0.2.2 && <0.6
     - uri-bytestring
     - yesod-auth >=1.6.0 && <1.7
     - yesod-core >=1.6.0 && <1.7

--- a/src/Yesod/Auth/OAuth2.hs
+++ b/src/Yesod/Auth/OAuth2.hs
@@ -52,7 +52,7 @@ authOAuth2 name = authOAuth2Widget [whamlet|Login via #{name}|] name
 --
 authOAuth2Widget
     :: YesodAuth m
-    => WidgetT m IO ()
+    => WidgetFor m ()
     -> Text
     -> OAuth2
     -> FetchCreds m

--- a/src/Yesod/Auth/OAuth2/BattleNet.hs
+++ b/src/Yesod/Auth/OAuth2/BattleNet.hs
@@ -29,7 +29,7 @@ pluginName = "battle.net"
 
 oauth2BattleNet
     :: YesodAuth m
-    => WidgetT m IO () -- ^ Login widget
+    => WidgetFor m () -- ^ Login widget
     -> Text -- ^ User region (e.g. "eu", "cn", "us")
     -> Text -- ^ Client ID
     -> Text -- ^ Client Secret
@@ -64,6 +64,6 @@ wwwHost :: Text -> Host
 wwwHost "cn" = "www.battlenet.com.cn"
 wwwHost region = Host $ encodeUtf8 $ region <> ".battle.net"
 
-oAuth2BattleNet :: YesodAuth m => Text -> Text -> Text -> WidgetT m IO () -> AuthPlugin m
+oAuth2BattleNet :: YesodAuth m => Text -> Text -> Text -> WidgetFor m () -> AuthPlugin m
 oAuth2BattleNet i s r w = oauth2BattleNet w r i s
 {-# DEPRECATED oAuth2BattleNet "Use oauth2BattleNet" #-}

--- a/src/Yesod/Auth/OAuth2/EveOnline.hs
+++ b/src/Yesod/Auth/OAuth2/EveOnline.hs
@@ -30,9 +30,9 @@ data WidgetType m
     | SmallWhite
     | BigBlack
     | SmallBlack
-    | Custom (WidgetT m IO ())
+    | Custom (WidgetFor m ())
 
-asWidget :: YesodAuth m => WidgetType m -> WidgetT m IO ()
+asWidget :: YesodAuth m => WidgetType m -> WidgetFor m ()
 asWidget Plain = [whamlet|Login via eveonline|]
 asWidget BigWhite = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/4PTzeiAshqiM8osU2giO0Y/5cc4cb60bac52422da2e45db87b6819c/EVE_SSO_Login_Buttons_Large_White.png?w=270&h=45">|]
 asWidget BigBlack = [whamlet|<img src="https://images.contentful.com/idjq7aai9ylm/4fSjj56uD6CYwYyus4KmES/4f6385c91e6de56274d99496e6adebab/EVE_SSO_Login_Buttons_Large_Black.png?w=270&h=45">|]

--- a/stack-lts-10.3.yaml
+++ b/stack-lts-10.3.yaml
@@ -1,6 +1,0 @@
----
-resolver: lts-10.3
-extra-deps:
-  - http-types-0.12.1
-  - yesod-auth-1.6.3
-  - yesod-core-1.6.3

--- a/stack-lts-10.3.yaml
+++ b/stack-lts-10.3.yaml
@@ -1,0 +1,6 @@
+---
+resolver: lts-10.3
+extra-deps:
+  - http-types-0.12.1
+  - yesod-auth-1.6.3
+  - yesod-core-1.6.3

--- a/stack-lts-11.5.yaml
+++ b/stack-lts-11.5.yaml
@@ -1,0 +1,4 @@
+---
+resolver: lts-11.5
+extra-deps:
+  - hoauth2-1.7.1

--- a/stack-lts-9.21.yaml
+++ b/stack-lts-9.21.yaml
@@ -2,3 +2,5 @@
 resolver: lts-9.21
 extra-deps:
   - load-env-0.1.2
+  - yesod-auth-1.6.1
+  - yesod-core-1.6.1

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -5,3 +5,4 @@
 resolver: lts-11.5
 extra-deps:
   - hoauth2-1.7.1
+  - uri-bytestring-aeson-0.1.0.6

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,4 @@
+---
+resolver: nightly
+extra-deps:
+  - hoauth2-1.7.1

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,4 +1,7 @@
 ---
-resolver: nightly
+# You can't use "nightly" here, only "nightly-<date>", apparently. But you
+# can't leave it blank either, so here's a value that we'll override by
+# --resolver nightly.
+resolver: lts-11.5
 extra-deps:
   - hoauth2-1.7.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
 ---
-resolver: lts-10.7
-
+resolver: lts-11.5
+extra-deps:
+  - hoauth2-1.7.1
 ghc-options:
-   "$locals": -fhide-source-paths
+  "$locals": -fhide-source-paths


### PR DESCRIPTION
- Latest LTS-11.5
- Allow hoauth2-1.7, needs to be extra-dep though
- Support *and require* yesod-1.6

  This required:

  - Less lifts
  - HandlerFor, WidgetFor, etc
  - Lost MonadThrow, but can use MonadIO instead