### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,10 @@ jobs:
     <<: *stack_build
     environment:
       STACK_ARGUMENTS: --stack-yaml stack-lts-11.18.yaml
+  build_8.4.3:
+    <<: *stack_build
+    environment:
+      STACK_ARGUMENTS: --stack-yaml stack-lts-12.2.yaml
   build:
     <<: *stack_build
   build_nightly:
@@ -53,5 +57,6 @@ workflows:
   builds:
     jobs:
       - build_8.2.2
+      - build_8.4.3
       - build
       - build_nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,9 @@ jobs:
   build_8.2.2:
     <<: *stack_build
     environment:
-      STACK_ARGUMENTS: --stack-yaml stack-lts-11.18.yaml
+      # Set this one via ENV var so that weeder respects it too. See
+      # https://github.com/ndmitchell/weeder/issues/41.
+      STACK_YAML: stack-lts-11.18.yaml
   build_8.4.3:
     <<: *stack_build
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   build_8.2.2:
     <<: *stack_build
     environment:
-      STACK_ARGUMENTS: --stack-yaml stack-lts-11.5.yaml
+      STACK_ARGUMENTS: --stack-yaml stack-lts-11.18.yaml
   build:
     <<: *stack_build
   build_nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,19 @@ jobs:
 
 workflows:
   version: 2
-  builds:
+  commit:
     jobs:
       - build_8.2.2
       - build_8.4.3
       - build
+      - build_nightly
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
       - build_nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,20 +34,9 @@ references:
           command: make test
       - run:
           name: Lint
-          command: |
-            if [ "${LINT:-1}" -eq 0 ]; then
-              echo "[LINT=0] Lint step skipped." >&2
-            else
-              make lint
-            fi
+          command: make lint
 
 jobs:
-  build_8.0.2:
-    <<: *stack_build
-    environment:
-      # FIXME: https://circleci.com/gh/thoughtbot/yesod-auth-oauth2/115
-      LINT: "0"
-      STACK_ARGUMENTS: --stack-yaml stack-lts-9.21.yaml
   build_8.2.2:
     <<: *stack_build
     environment:
@@ -63,7 +52,6 @@ workflows:
   version: 2
   builds:
     jobs:
-      # - build_8.0.2
       - build_8.2.2
       - build
       - build_nightly

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ setup:
 	stack build $(STACK_ARGUMENTS) \
 	  --flag yesod-auth-oauth2:example \
 	  --dependencies-only --test --no-run-tests
-	stack install $(STACK_ARGUMENTS) hlint weeder
+	stack install $(STACK_ARGUMENTS) --copy-compiler-tool hlint weeder
 
 .PHONY: build
 build:
@@ -23,8 +23,8 @@ test:
 
 .PHONY: lint
 lint:
-	hlint src test
-	weeder .
+	stack exec hlint src test
+	stack exec weeder .
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ test:
 
 .PHONY: lint
 lint:
-	stack exec hlint src test
-	stack exec weeder .
+	stack exec $(STACK_ARGUMENTS) hlint src test
+	stack exec $(STACK_ARGUMENTS) weeder .
 
 .PHONY: clean
 clean:

--- a/stack-lts-11.18.yaml
+++ b/stack-lts-11.18.yaml
@@ -1,0 +1,4 @@
+---
+resolver: lts-11.18
+extra-deps:
+  - hoauth2-1.7.2

--- a/stack-lts-11.5.yaml
+++ b/stack-lts-11.5.yaml
@@ -1,4 +1,0 @@
----
-resolver: lts-11.5
-extra-deps:
-  - hoauth2-1.7.1

--- a/stack-lts-12.2.yaml
+++ b/stack-lts-12.2.yaml
@@ -1,0 +1,8 @@
+---
+resolver: lts-12.2
+extra-deps:
+  - hoauth2-1.7.2
+  - uri-bytestring-aeson-0.1.0.6
+
+# needed so resourcet can get exceptions-0.10 even though hoauth dislikes it
+allow-newer: true

--- a/stack-lts-9.21.yaml
+++ b/stack-lts-9.21.yaml
@@ -1,6 +1,0 @@
----
-resolver: lts-9.21
-extra-deps:
-  - load-env-0.1.2
-  - yesod-auth-1.6.1
-  - yesod-core-1.6.1

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -3,6 +3,7 @@
 # can't leave it blank either, so here's a value that we'll override by
 # --resolver nightly.
 resolver: lts-11.5
+allow-newer: true
 extra-deps:
-  - hoauth2-1.7.1
+  - hoauth2-1.7.2
   - uri-bytestring-aeson-0.1.0.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,10 @@
 ---
-resolver: lts-11.5
+resolver: lts-12.2
 extra-deps:
-  - hoauth2-1.7.1
+  - hoauth2-1.7.2
+  - uri-bytestring-aeson-0.1.0.6
 ghc-options:
   "$locals": -fhide-source-paths
+
+# needed so resourcet can get exceptions-0.10 even though hoauth dislikes it
+allow-newer: true


### PR DESCRIPTION
- Drop the disabled 8.0.2 build, I can't make it work
- Update resolver for 8.2 build to latest LTS with that compiler
- Add an 8.4 build, now that that's out
- Update default stack resolver to latest LTS
- Update nightly to allow-newer to hopefully avoid frequent maintenance
- Configure CI to build nightly each night to avoid finding out only when we
  work on it that it's broken