### PR TITLE
Redirect on OAuth2 errors, not permissionDenied

### DIFF
--- a/src/Yesod/Auth/OAuth2/ErrorResponse.hs
+++ b/src/Yesod/Auth/OAuth2/ErrorResponse.hs
@@ -5,8 +5,10 @@
 --
 module Yesod.Auth.OAuth2.ErrorResponse
     ( ErrorResponse(..)
+    , erUserMessage
     , ErrorName(..)
     , onErrorResponse
+    , unknownError
     ) where
 
 import Data.Foldable (traverse_)
@@ -31,6 +33,25 @@ data ErrorResponse = ErrorResponse
     , erURI :: Maybe Text
     }
     deriving Show
+
+-- | Textual value suitable for display to a User
+erUserMessage :: ErrorResponse -> Text
+erUserMessage err = case erName err of
+    InvalidRequest -> "Invalid request"
+    UnauthorizedClient -> "Unauthorized client"
+    AccessDenied -> "Access denied"
+    UnsupportedResponseType -> "Unsupported response type"
+    InvalidScope -> "Invalid scope"
+    ServerError -> "Server error"
+    TemporarilyUnavailable -> "Temporarily unavailable"
+    Unknown _ -> "Unknown error"
+
+unknownError :: Text -> ErrorResponse
+unknownError x = ErrorResponse
+    { erName = Unknown x
+    , erDescription = Nothing
+    , erURI = Nothing
+    }
 
 -- | Check query parameters for an error, if found run the given action
 --

--- a/src/Yesod/Auth/OAuth2/Exception.hs
+++ b/src/Yesod/Auth/OAuth2/Exception.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Yesod.Auth.OAuth2.Exception
+    ( YesodOAuth2Exception(..)
+    ) where
+
+import Control.Exception.Safe
+import qualified Data.ByteString.Lazy as BL
+import Data.Text (Text)
+
+-- | Provider name and error
+--
+-- The error is a lazy bytestring because it's most often encoded JSON.
+--
+-- Deprecated. Eventually, we'll return @Either@s all the way up.
+--
+data YesodOAuth2Exception = InvalidProfileResponse Text BL.ByteString
+    deriving (Show, Typeable)
+instance Exception YesodOAuth2Exception

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 -- |
@@ -8,10 +6,9 @@
 -- implementations. May also be useful for writing local providers.
 --
 module Yesod.Auth.OAuth2.Prelude
-    ( YesodOAuth2Exception(..)
-
-    -- * Provider helpers
-    , authGetProfile
+    (
+      -- * Provider helpers
+      authGetProfile
     , scopeParam
     , setExtra
 
@@ -55,6 +52,7 @@ module Yesod.Auth.OAuth2.Prelude
     , module URI.ByteString.Extension
 
     -- * Temporary, until I finish re-structuring modules
+    , YesodOAuth2Exception(..)
     , authOAuth2
     , authOAuth2Widget
     ) where
@@ -74,16 +72,7 @@ import URI.ByteString
 import URI.ByteString.Extension
 import Yesod.Auth
 import Yesod.Auth.OAuth2
-
--- | Provider name and error
---
--- The error is a lazy bytestring because it's most often encoded JSON.
---
--- Deprecated. Eventually, we'll return @Either@s all the way up.
---
-data YesodOAuth2Exception = InvalidProfileResponse Text BL.ByteString
-    deriving (Show, Typeable)
-instance Exception YesodOAuth2Exception
+import Yesod.Auth.OAuth2.Exception
 
 -- | Retrieve a user's profile as JSON
 --

--- a/src/Yesod/Auth/OAuth2/Prelude.hs
+++ b/src/Yesod/Auth/OAuth2/Prelude.hs
@@ -91,26 +91,37 @@ instance Exception YesodOAuth2Exception
 -- @'credsIdent'@. Additional information should either be re-parsed by or
 -- fetched via additional requests by consumers.
 --
-authGetProfile :: FromJSON a => Text -> Manager -> OAuth2Token -> URI -> IO (a, BL.ByteString)
+authGetProfile
+    :: FromJSON a
+    => Text
+    -> Manager
+    -> OAuth2Token
+    -> URI
+    -> IO (a, BL.ByteString)
 authGetProfile name manager token url = do
     resp <- fromAuthGet name =<< authGetBS manager (accessToken token) url
     decoded <- fromAuthJSON name resp
     pure (decoded, resp)
 
 -- | Throws a @Left@ result as an @'InvalidProfileResponse'@
-fromAuthGet :: Text -> Either (OAuth2Error Value) BL.ByteString -> IO BL.ByteString
+fromAuthGet
+    :: Text -> Either (OAuth2Error Value) BL.ByteString -> IO BL.ByteString
 fromAuthGet _ (Right bs) = pure bs -- nice
-fromAuthGet name (Left err) = throwIO $ InvalidProfileResponse name $ encode err
+fromAuthGet name (Left err) =
+    throwIO $ InvalidProfileResponse name $ encode err
 
 -- | Throws a decoding error as an @'InvalidProfileResponse'@
 fromAuthJSON :: FromJSON a => Text -> BL.ByteString -> IO a
 fromAuthJSON name =
     -- FIXME: unique exception constructors
-    either (throwIO . InvalidProfileResponse name . BL8.pack) pure . eitherDecode
+    either (throwIO . InvalidProfileResponse name . BL8.pack) pure
+        . eitherDecode
 
 -- | A tuple of @\"scope\"@ and the given scopes separated by a delimiter
 scopeParam :: Text -> [Text] -> (ByteString, ByteString)
-scopeParam d = ("scope",) . encodeUtf8 . T.intercalate d
+scopeParam d = ("scope", ) . encodeUtf8 . T.intercalate d
+
+-- brittany-disable-next-binding
 
 -- | Construct part of @'credsExtra'@
 --
@@ -128,4 +139,4 @@ setExtra token userResponse =
     [ ("accessToken", atoken $ accessToken token)
     , ("userResponse", decodeUtf8 $ BL.toStrict userResponse)
     ]
-    <> maybe [] (pure . ("refreshToken",) . rtoken) (refreshToken token)
+    <> maybe [] (pure . ("refreshToken", ) . rtoken) (refreshToken token)


### PR DESCRIPTION
And ensure we rescue our InvalidProfile exceptions too.

Overall, this makes the library less likely to cause you 4XX or 5XX
errors due to mis-behaving plugins (and even some expected user actions
such as denying the grant). Instead, we'll always redirect to the login
page with a message set about the issue (for the user) and more details
in the server logs (for you).