### PR TITLE
Add AzureAD provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [*Unreleased*](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.1.0...master)
 
 - Test with GHC 8.6.3, and not 8.2
+- Added AzureAD provider
+- COMPATIBILITY: Use `hoauth2-1.8.1`
 
 ## [v0.6.1.0](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.0.0...v0.6.1.0)
 

--- a/src/Yesod/Auth/OAuth2/AzureAD.hs
+++ b/src/Yesod/Auth/OAuth2/AzureAD.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- |
+--
+-- OAuth2 plugin for Azure AD.
+--
+-- * Authenticates against Azure AD
+-- * Uses email as credentials identifier
+--
+module Yesod.Auth.OAuth2.AzureAD
+    ( oauth2AzureAD
+    , oauth2AzureADScoped
+    ) where
+
+import Prelude
+import Yesod.Auth.OAuth2.Prelude
+
+newtype User = User Text
+
+instance FromJSON User where
+    parseJSON = withObject "User" $ \o -> User
+        <$> o .: "mail"
+
+pluginName :: Text
+pluginName = "azuread"
+
+defaultScopes :: [Text]
+defaultScopes = ["openid", "profile"]
+
+oauth2AzureAD :: YesodAuth m => Text -> Text -> AuthPlugin m
+oauth2AzureAD = oauth2AzureADScoped defaultScopes
+
+oauth2AzureADScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
+oauth2AzureADScoped scopes clientId clientSecret =
+    authOAuth2 pluginName oauth2 $ \manager token -> do
+        (User userId, userResponse) <-
+            authGetProfile pluginName manager token "https://graph.microsoft.com/v1.0/me"
+
+        pure Creds
+            { credsPlugin = pluginName
+            , credsIdent = userId
+            , credsExtra = setExtra token userResponse
+            }
+  where
+    oauth2 = OAuth2
+        { oauthClientId = clientId
+        , oauthClientSecret = clientSecret
+        , oauthOAuthorizeEndpoint = "https://login.windows.net/common/oauth2/authorize" `withQuery`
+            [ scopeParam "," scopes
+            , ("resource", "https://graph.microsoft.com")
+            ]
+        , oauthAccessTokenEndpoint = "https://login.windows.net/common/oauth2/token"
+        , oauthCallback = Nothing
+        }

--- a/stack-lts-12.2.yaml
+++ b/stack-lts-12.2.yaml
@@ -1,7 +1,7 @@
 ---
 resolver: lts-12.2
 extra-deps:
-  - hoauth2-1.7.2
+  - hoauth2-1.8.1
   - uri-bytestring-aeson-0.1.0.6
 
 # needed so resourcet can get exceptions-0.10 even though hoauth dislikes it


### PR DESCRIPTION
`hoauth2-1.8.1` incorporated [my PR](https://github.com/freizl/hoauth2/pull/97) for more flexible `expiresIn` parsing on `OAuth2Token`. With this, it's now super straightforward to add support for AzureAD as a provider.