### PR TITLE
Fix a link in package.yaml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -7,7 +7,7 @@ category: Web
 author: Tom Streller
 maintainer: Pat Brisbin <pbrisbin@gmail.com>
 license: MIT
-github: thoughtbot/yesod-auth-oauth2.git
+github: thoughtbot/yesod-auth-oauth2
 homepage: http://github.com/thoughtbot/yesod-auth-oauth2
 
 ghc-options: -Wall


### PR DESCRIPTION
The `.git` is redundant because on hackage the link of Bug tracker would be `https://github.com/thoughtbot/yesod-auth-oauth2.git/issues` and it is not a valid link.