### PR TITLE
Build Cabal in -j 1 step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ setup.lint:
 
 .PHONY: dependencies
 dependencies:
-	stack build $(STACK_ARGUMENTS) -j 1 haskell-src-exts
+	stack build $(STACK_ARGUMENTS) -j 1 Cabal haskell-src-exts
 	stack build $(STACK_ARGUMENTS) \
 	  --flag yesod-auth-oauth2:example \
 	  --dependencies-only --test --no-run-tests


### PR DESCRIPTION
Un-cached builds cannot succeed without exhausting memory. Doing fewer
packages concurrently can sometimes resolve this. This is trial and
error.

https://app.circleci.com/jobs/github/thoughtbot/yesod-auth-oauth2/1022