### PR TITLE
Send client credentials in the request body when fetching the access token

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ library:
     - aeson >=0.6 && <1.5
     - bytestring >=0.9.1.4
     - errors
-    - hoauth2 >=1.3.0 && <1.9
+    - hoauth2 >=1.7.0 && <1.11
     - http-client >=0.4.0 && <0.7
     - http-conduit >=2.0 && <3.0
     - http-types >=0.8 && <0.13

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -67,7 +67,7 @@ dispatchCallback name oauth2 getCreds = do
     code <- requireGetParam "code"
     manager <- authHttpManager
     oauth2' <- withCallbackAndState name oauth2 csrf
-    token <- errLeft $ fetchAccessToken manager oauth2' $ ExchangeToken code
+    token <- errLeft $ fetchAccessToken2 manager oauth2' $ ExchangeToken code
     creds <- errLeft $ tryFetchCreds $ getCreds manager token
     setCredsRedirect creds
   where


### PR DESCRIPTION
Bump version of `hoauth2` dependency, and replace call to `fetchAccessToken` by `fetchAccessToken2`.

`fetchAccessToken2` is a drop-in replacement for `fetchAccessToken` that just adds `client_id` and `client_secret` to the request body as form parameters, as permitted by [RFC 6749](https://tools.ietf.org/html/rfc6749#section-2.3.1). Some authorization server implementations only accept client credentials in this form. This function was introduced in 1.7.0 and amended in 1.11.0; either the initial or the amended version of `fetchAccessToken2` would work for this, but here we've chosen the most conservative working version bump.

This is deployed for live testing to http://yesod-auth-oauth2-example.herokuapp.com/, along with #130, from https://github.com/nbloomf/yesod-auth-oauth2/pull/2.

Testing checklist:
- [ ] Azure AD
- [ ] BattleNet
- [x] BitBucket
- [ ] Eve Online
- [x] GitHub
- [x] GitLab
- [x] Google
- [ ] Nylas
- [ ] Salesforce
- [x] Slack
- [x] Spotify
- [x] WordPressDotCom
- [ ] Upcase

Fixes #127 