### PR TITLE
Use mwc-random for CSRF state token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add WordPress.com provider
   [@nbloomf](https://github.com/thoughtbot/yesod-auth-oauth2/pull/130)
 - Allow aeson-1.5 and hoauth2-1.14
+- Replace `System.Random` state token generation with `cryptonite`
 
 ## [v0.6.1.2](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.1.1...v0.6.1.2)
 

--- a/package.yaml
+++ b/package.yaml
@@ -24,13 +24,14 @@ library:
   dependencies:
     - aeson >=0.6 && <1.6
     - bytestring >=0.9.1.4
+    - cryptonite
     - errors
     - hoauth2 >=1.7.0 && <1.15
     - http-client >=0.4.0 && <0.7
     - http-conduit >=2.0 && <3.0
     - http-types >=0.8 && <0.13
+    - memory
     - microlens
-    - random
     - safe-exceptions
     - text >=0.7 && <2.0
     - uri-bytestring


### PR DESCRIPTION
System.Random uses the system clock as input to the seed, which may
expose us to offline attacks. mwc-random does not do this (except as a
fallback in rare cases).

Fixes #132.

NOTE: The interface for mwc-random in 0.14 (current resolver) vs 0.15
(latest) is wildly different. So when we attempt to update, we'll have
to consider either CPP or extra-deps in old resolvers.

/cc @lf-