### PR TITLE
Tighten upper bound on hauth2

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,7 @@ library:
     - bytestring >=0.9.1.4
     - cryptonite
     - errors
-    - hoauth2 >=1.7.0 && <1.15
+    - hoauth2 >=1.7.0 && <1.9
     - http-client >=0.4.0 && <0.7
     - http-conduit >=2.0 && <3.0
     - http-types >=0.8 && <0.13


### PR DESCRIPTION
We need to avoid 1.9, where authGetBS changes type. This was the case
until 0036d5f, where it was changed unintentionally.

Fixes #135.