### PR TITLE
Support injecting fetchAccessToken

### DIFF
--- a/src/Yesod/Auth/OAuth2.hs
+++ b/src/Yesod/Auth/OAuth2.hs
@@ -17,6 +17,10 @@ module Yesod.Auth.OAuth2
     , authOAuth2
     , authOAuth2Widget
 
+    -- * Alternatives that use 'fetchAccessToken2'
+    , authOAuth2'
+    , authOAuth2Widget'
+
     -- * Reading our @'credsExtra'@ keys
     , getAccessToken
     , getRefreshToken
@@ -47,6 +51,13 @@ oauth2Url name = PluginR name ["forward"]
 authOAuth2 :: YesodAuth m => Text -> OAuth2 -> FetchCreds m -> AuthPlugin m
 authOAuth2 name = authOAuth2Widget [whamlet|Login via #{name}|] name
 
+-- | A version of 'authOAuth2' that uses 'fetchAccessToken2'
+--
+-- See <https://github.com/thoughtbot/yesod-auth-oauth2/pull/129>
+--
+authOAuth2' :: YesodAuth m => Text -> OAuth2 -> FetchCreds m -> AuthPlugin m
+authOAuth2' name = authOAuth2Widget' [whamlet|Login via #{name}|] name
+
 -- | Create an @'AuthPlugin'@ for the given OAuth2 provider
 --
 -- Allows passing a custom widget for the login link. See @'oauth2Eve'@ for an
@@ -59,10 +70,34 @@ authOAuth2Widget
     -> OAuth2
     -> FetchCreds m
     -> AuthPlugin m
-authOAuth2Widget widget name oauth getCreds =
-    AuthPlugin name (dispatchAuthRequest name oauth getCreds) login
-  where
-    login tm = [whamlet|<a href=@{tm $ oauth2Url name}>^{widget}|]
+authOAuth2Widget = buildPlugin fetchAccessToken
+
+-- | A version of 'authOAuth2Widget' that uses 'fetchAccessToken2'
+--
+-- See <https://github.com/thoughtbot/yesod-auth-oauth2/pull/129>
+--
+authOAuth2Widget'
+    :: YesodAuth m
+    => WidgetFor m ()
+    -> Text
+    -> OAuth2
+    -> FetchCreds m
+    -> AuthPlugin m
+authOAuth2Widget' = buildPlugin fetchAccessToken2
+
+buildPlugin
+    :: YesodAuth m
+    => FetchToken
+    -> WidgetFor m ()
+    -> Text
+    -> OAuth2
+    -> FetchCreds m
+    -> AuthPlugin m
+buildPlugin getToken widget name oauth getCreds = AuthPlugin
+    name
+    (dispatchAuthRequest name oauth getToken getCreds)
+    login
+    where login tm = [whamlet|<a href=@{tm $ oauth2Url name}>^{widget}|]
 
 -- | Read the @'AccessToken'@ from the values set via @'setExtra'@
 getAccessToken :: Creds m -> Maybe AccessToken

--- a/src/Yesod/Auth/OAuth2.hs
+++ b/src/Yesod/Auth/OAuth2.hs
@@ -22,7 +22,8 @@ module Yesod.Auth.OAuth2
     , getRefreshToken
     , getUserResponse
     , getUserResponseJSON
-    ) where
+    )
+where
 
 import Control.Error.Util (note)
 import Control.Monad ((<=<))
@@ -65,16 +66,14 @@ authOAuth2Widget widget name oauth getCreds =
 
 -- | Read the @'AccessToken'@ from the values set via @'setExtra'@
 getAccessToken :: Creds m -> Maybe AccessToken
-getAccessToken =
-    (AccessToken <$>) . lookup "accessToken" . credsExtra
+getAccessToken = (AccessToken <$>) . lookup "accessToken" . credsExtra
 
 -- | Read the @'RefreshToken'@ from the values set via @'setExtra'@
 --
 -- N.B. not all providers supply this value.
 --
 getRefreshToken :: Creds m -> Maybe RefreshToken
-getRefreshToken =
-    (RefreshToken <$>) . lookup "refreshToken" . credsExtra
+getRefreshToken = (RefreshToken <$>) . lookup "refreshToken" . credsExtra
 
 -- | Read the original profile response from the values set via @'setExtra'@
 getUserResponse :: Creds m -> Maybe ByteString

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -63,7 +63,11 @@ dispatchForward name oauth2 = do
 -- 2. Use the code parameter to fetch an AccessToken for the Provider
 -- 3. Use the AccessToken to construct a @'Creds'@ value for the Provider
 --
-dispatchCallback :: Text -> OAuth2 -> FetchCreds m -> AuthHandler m TypedContent
+dispatchCallback
+    :: Text
+    -> OAuth2
+    -> FetchCreds m
+    -> AuthHandler m TypedContent
 dispatchCallback name oauth2 getCreds = do
     csrf <- verifySessionCSRF $ tokenSessionKey name
     onErrorResponse $ oauth2HandshakeError name


### PR DESCRIPTION
hoauth2's `fetchAccessToken` provides credentials in the Authorization header,
while `fetchAccessToken2` provides them in that header but also the POST body.

It was discovered that some providers only support one or the other, so 
using `fetchAccessToken2` would be preferred since it should work with 
either. This happened in #129.

However, we discovered at least one provider (Okta) that actively rejects
requests unless they're supplying credentials in exactly one place:

> Cannot supply multiple client credentials. Use one of the following:
> credentials in the Authorization header, credentials in the post body, or a
> `client_assertion` in the post body."

This patch reverts back to `fetchAccessToken`, but makes it possible to for
client to use `fetchAccessToken2` if necessary via alternative functions.