### PR TITLE
Fix STACK_YAML in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,4 @@ jobs:
           HACKAGE_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
 
           # Use minimum LTS to set lowest lower bounds
-          STACK_YAML: stack-lts-16.31.yaml
+          STACK_YAML: stack-lts21.yaml


### PR DESCRIPTION
We removed some resolvers, so we need to update the minimum that's used
here.
